### PR TITLE
TEL-650

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/LogMessageThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.alertconfig.builders
 
 trait AlertConfig {
   def alertConfig: Seq[AlertConfigBuilder]
+  def environmentConfig: Seq[EnvironmentAlertBuilder]
 
   implicit def teamAlertConfigToAlertConfigs(config: TeamAlertConfigBuilder): Seq[AlertConfigBuilder] = config.build
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.alertconfig.builders
 
 import spray.json.{JsArray, JsNull, JsObject, JsString, JsValue}

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -1,6 +1,6 @@
 package uk.gov.hmrc.alertconfig.builders
 
-import spray.json.{JsArray, JsObject, JsString, JsValue}
+import spray.json.{JsArray, JsNull, JsObject, JsString, JsValue}
 
 sealed trait Severity {
   override def toString: String = this.getClass.getSimpleName.toLowerCase.replace("$", "")
@@ -21,27 +21,40 @@ object ExternalTest extends Environment
 object Management extends Environment
 object Production extends Environment
 
+object AllEnvironmentAlertConfigBuilder {
+  def build(builders: Iterable[EnvironmentAlertBuilder]): Map[Environment, JsObject] =
+    Seq(Integration, Development, Qa, Staging, ExternalTest, Management, Production).map( e =>
+    e -> JsObject("handlers" -> JsObject(builders.map(b => b.alertConfigFor(e)).toList.sortBy(_._1) : _*))).toMap
+}
+
 case class EnvironmentAlertBuilder(handlerName:String, enabledEnvironments: Map[Environment, Set[Severity]] = Map((Production, Set(Ok, Warning, Critical)))) {
   private val defaultSeverities: Set[Severity] = Set(Ok, Warning, Critical)
-  def inIntegration(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Integration -> severities))
-  def inDevelopment(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Development -> severities))
-  def inQa(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Qa -> severities))
-  def inStaging(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Staging -> severities))
-  def inExternalTest(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (ExternalTest -> severities))
-  def inManagement(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Management -> severities))
-  def inProduction(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Production -> severities))
+  def inIntegration(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder =
+    this.copy(enabledEnvironments = enabledEnvironments + (Integration -> severities))
+  def inDevelopment(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder =
+    this.copy(enabledEnvironments = enabledEnvironments + (Development -> severities))
+  def inQa(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder =
+    this.copy(enabledEnvironments = enabledEnvironments + (Qa -> severities))
+  def inStaging(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder =
+    this.copy(enabledEnvironments = enabledEnvironments + (Staging -> severities))
+  def inExternalTest(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder =
+    this.copy(enabledEnvironments = enabledEnvironments + (ExternalTest -> severities))
+  def inManagement(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder =
+    this.copy(enabledEnvironments = enabledEnvironments + (Management -> severities))
+  def inProduction(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder =
+    this.copy(enabledEnvironments = enabledEnvironments + (Production -> severities))
 
-  def alertConfigFor(environment: Environment): JsValue =
-    JsObject(handlerName ->
+  def alertConfigFor(environment: Environment): (String, JsObject) =
+    handlerName ->
       JsObject(
-        "command" -> commandFor(environment),
+        "command" -> commandFor(handlerName, environment),
         "type" -> JsString("pipe"),
         "severities" ->  severitiesFor(environment),
-        "filter" -> JsString("occurrences")))
+        "filter" -> JsString("occurrences"))
 
-  private def commandFor(environment: Environment): JsValue =
+  private def commandFor(service: String, environment: Environment): JsValue =
     if (enabledEnvironments.contains(environment))
-      JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e $environment")
+      JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team $service -e $environment")
     else
       JsString("/etc/sensu/handlers/noop.rb")
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -1,0 +1,51 @@
+package uk.gov.hmrc.alertconfig.builders
+
+import spray.json.{JsArray, JsObject, JsString, JsValue}
+
+sealed trait Severity {
+  override def toString: String = this.getClass.getSimpleName.toLowerCase.replace("$", "")
+}
+object Ok extends Severity
+object Warning extends Severity
+object Critical extends Severity
+object Unknown extends Severity
+
+sealed trait Environment {
+  override def toString: String = s"aws_${this.getClass.getSimpleName.toLowerCase.replace("$", "")}"
+}
+object Integration extends Environment
+object Development extends Environment
+object Qa extends Environment
+object Staging extends Environment
+object ExternalTest extends Environment
+object Management extends Environment
+object Production extends Environment
+
+case class EnvironmentAlertBuilder(handlerName:String, enabledEnvironments: Map[Environment, Set[Severity]] = Map((Production, Set(Ok, Warning, Critical)))) {
+  private val defaultSeverities: Set[Severity] = Set(Ok, Warning, Critical)
+  def inIntegration(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Integration -> severities))
+  def inDevelopment(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Development -> severities))
+  def inQa(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Qa -> severities))
+  def inStaging(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Staging -> severities))
+  def inExternalTest(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (ExternalTest -> severities))
+  def inManagement(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Management -> severities))
+  def inProduction(severities: Set[Severity] = defaultSeverities): EnvironmentAlertBuilder = this.copy(enabledEnvironments = enabledEnvironments + (Production -> severities))
+
+  def alertConfigFor(environment: Environment): JsValue =
+    JsObject(handlerName ->
+      JsObject(
+        "command" -> commandFor(environment),
+        "type" -> JsString("pipe"),
+        "severities" ->  severitiesFor(environment),
+        "filter" -> JsString("occurrences")))
+
+  private def commandFor(environment: Environment): JsValue =
+    if (enabledEnvironments.contains(environment))
+      JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e $environment")
+    else
+      JsString("/etc/sensu/handlers/noop.rb")
+
+  private def severitiesFor(environment: Environment) =
+    JsArray(enabledEnvironments.getOrElse(environment, defaultSeverities).map(s => JsString(s.toString)).toVector)
+
+}

--- a/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.alertconfig.builders
 
 import org.scalatest.{BeforeAndAfterEach, FunSuite, Matchers}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -1,0 +1,49 @@
+package uk.gov.hmrc.alertconfig.builders
+
+import org.scalatest.{BeforeAndAfterEach, FunSuite, Matchers}
+import spray.json.{JsArray, JsObject, JsString}
+
+class AllEnvironmentAlertConfigBuilderSpec extends FunSuite with Matchers with BeforeAndAfterEach {
+
+  def defaultNoopHandlerConfig: JsObject =
+    JsObject(
+      "command" -> JsString("/etc/sensu/handlers/noop.rb"),
+      "type" -> JsString("pipe"),
+      "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+      "filter" -> JsString("occurrences"))
+
+  def defaultEnabledHandlerConfig(service: String, environment: Environment): JsObject =
+    JsObject(
+      "command" -> JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team $service -e $environment"),
+      "type" -> JsString("pipe"),
+      "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+      "filter" -> JsString("occurrences"))
+
+    Seq(Integration, Development, Staging, Qa, ExternalTest, Management).foreach{
+    e =>
+      test(s"create config for $e") {
+        val environmentConfigMap = AllEnvironmentAlertConfigBuilder.build(
+          Set(EnvironmentAlertBuilder("team-telemetry"), EnvironmentAlertBuilder("infra")))
+
+        environmentConfigMap(e) shouldBe
+          JsObject("handlers" -> JsObject(
+            "infra" -> defaultNoopHandlerConfig,
+            "team-telemetry" -> defaultNoopHandlerConfig
+          )
+          )
+      }
+    }
+
+    test("create config for production") {
+      val environmentConfigMap = AllEnvironmentAlertConfigBuilder.build(
+        Set(EnvironmentAlertBuilder("team-telemetry"), EnvironmentAlertBuilder("infra")))
+
+      environmentConfigMap(Production) shouldBe
+        JsObject("handlers" -> JsObject(
+          "infra" -> defaultEnabledHandlerConfig("infra", Production),
+          "team-telemetry" -> defaultEnabledHandlerConfig("team-telemetry", Production)
+        )
+        )
+    }
+
+}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.alertconfig.builders
 
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -1,0 +1,51 @@
+package uk.gov.hmrc.alertconfig.builders
+
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import spray.json._
+
+class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAndAfterEach {
+
+  "EnvironmentAlertBuilder" should {
+    "create config with production enabled with default severities" in {
+      EnvironmentAlertBuilder("team-telemetry").inProduction().alertConfigFor(Production) shouldBe
+        JsObject("team-telemetry" ->
+          JsObject(
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e aws_production"),
+            "type" -> JsString("pipe"),
+            "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+            "filter" -> JsString("occurrences")))
+    }
+
+    "create config with integration enabled with default severities" in {
+      EnvironmentAlertBuilder("team-telemetry").inIntegration().alertConfigFor(Integration) shouldBe
+        JsObject("team-telemetry" ->
+          JsObject(
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e aws_integration"),
+            "type" -> JsString("pipe"),
+            "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+            "filter" -> JsString("occurrences")))
+    }
+
+    "create config with integration disabled" in {
+      EnvironmentAlertBuilder("team-telemetry").alertConfigFor(Integration) shouldBe
+        JsObject("team-telemetry" ->
+          JsObject(
+            "command" -> JsString("/etc/sensu/handlers/noop.rb"),
+            "type" -> JsString("pipe"),
+            "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+            "filter" -> JsString("occurrences")))
+    }
+
+    "create config with integration enabled with custom severities" in {
+      EnvironmentAlertBuilder("team-telemetry").inIntegration(Set(Ok, Warning, Critical, Unknown)).alertConfigFor(Integration) shouldBe
+        JsObject("team-telemetry" ->
+          JsObject(
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e aws_integration"),
+            "type" -> JsString("pipe"),
+            "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical"), JsString("unknown")),
+            "filter" -> JsString("occurrences")))
+    }
+
+
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -8,42 +8,42 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
   "EnvironmentAlertBuilder" should {
     "create config with production enabled with default severities" in {
       EnvironmentAlertBuilder("team-telemetry").inProduction().alertConfigFor(Production) shouldBe
-        JsObject("team-telemetry" ->
+        "team-telemetry" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e aws_production"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team team-telemetry -e aws_production"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
-            "filter" -> JsString("occurrences")))
+            "filter" -> JsString("occurrences"))
     }
 
     "create config with integration enabled with default severities" in {
-      EnvironmentAlertBuilder("team-telemetry").inIntegration().alertConfigFor(Integration) shouldBe
-        JsObject("team-telemetry" ->
+      EnvironmentAlertBuilder("infra").inIntegration().alertConfigFor(Integration) shouldBe
+        "infra" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e aws_integration"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team infra -e aws_integration"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
-            "filter" -> JsString("occurrences")))
+            "filter" -> JsString("occurrences"))
     }
 
     "create config with integration disabled" in {
-      EnvironmentAlertBuilder("team-telemetry").alertConfigFor(Integration) shouldBe
-        JsObject("team-telemetry" ->
+      EnvironmentAlertBuilder("team-telemetry-test").alertConfigFor(Integration) shouldBe
+        "team-telemetry-test" ->
           JsObject(
             "command" -> JsString("/etc/sensu/handlers/noop.rb"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
-            "filter" -> JsString("occurrences")))
+            "filter" -> JsString("occurrences"))
     }
 
     "create config with integration enabled with custom severities" in {
       EnvironmentAlertBuilder("team-telemetry").inIntegration(Set(Ok, Warning, Critical, Unknown)).alertConfigFor(Integration) shouldBe
-        JsObject("team-telemetry" ->
+        "team-telemetry" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team iprights -e aws_integration"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team team-telemetry -e aws_integration"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical"), JsString("unknown")),
-            "filter" -> JsString("occurrences")))
+            "filter" -> JsString("occurrences"))
     }
 
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 HM Revenue & Customs
+ * Copyright 2019 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Build sensu handler configuration using alert-config-builder rather than the current process of manually updates. AlertConfigBuilder now takes in a collection of one or more environments to receive Pager Duty alerts from. If an environment is configured to receive Pager Duty alerts, then when the Sensu server starts up it will register hmrc_pagerduty_multiteam_env.rb as the handler for its environment. If an environment is not configured, then it will register the NOOP handler for its environment.

Changes
Add support for environments to AlertConfigBuilder.
For each environment, generate a hmrc_handlers.json file. For each service defined, there will be a value stating whether the handler should be noop.rb or hmrc_pagerduty_multiteam_env.rb.