### PR TITLE
TEL-650 default environmentConfig implementation

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.alertconfig.builders
 
 trait AlertConfig {
   def alertConfig: Seq[AlertConfigBuilder]
-  def environmentConfig: Seq[EnvironmentAlertBuilder]
+  def environmentConfig: Seq[EnvironmentAlertBuilder] =
+    alertConfig.flatMap(_.handlers).toSet.map((h:String) => EnvironmentAlertBuilder(h)).toSeq
 
   implicit def teamAlertConfigToAlertConfigs(config: TeamAlertConfigBuilder): Seq[AlertConfigBuilder] = config.build
 }


### PR DESCRIPTION
Add a default implementation of environmentConfig in AlertConfig so that
all existing services have a production handler by default, then only
services with handlers in other environments need to be overridden