### PR TITLE
TEL-650 Allow disabling envs with custom command

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -66,7 +66,7 @@ case class EnvironmentAlertBuilder(handlerName:String, command:Option[JsValue] =
   def alertConfigFor(environment: Environment): (String, JsObject) = {
     handlerName ->
       JsObject(
-        "command" -> command.getOrElse(commandFor(handlerName, environment)),
+        "command" -> commandFor(handlerName, environment),
         "type" -> JsString("pipe"),
         "severities" ->  severitiesFor(environment),
         "filter" -> JsString("occurrences"))
@@ -74,7 +74,7 @@ case class EnvironmentAlertBuilder(handlerName:String, command:Option[JsValue] =
 
   private def commandFor(service: String, environment: Environment): JsValue =
     if (enabledEnvironments.contains(environment))
-      JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team $service -e $environment")
+      command.getOrElse(JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team $service -e $environment"))
     else
       JsString("/etc/sensu/handlers/noop.rb")
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -52,6 +52,16 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
             "filter" -> JsString("occurrences"))
     }
 
+    "create config with integration disabled with custom command" in {
+      EnvironmentAlertBuilder("infra").withCommand("/etc/sensu/handlers/dose-pagerduty-high.rb").alertConfigFor(Integration) shouldBe
+        "infra" ->
+          JsObject(
+            "command" -> JsString("/etc/sensu/handlers/noop.rb"),
+            "type" -> JsString("pipe"),
+            "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+            "filter" -> JsString("occurrences"))
+    }
+
     "create config with integration disabled" in {
       EnvironmentAlertBuilder("team-telemetry-test").alertConfigFor(Integration) shouldBe
         "team-telemetry-test" ->


### PR DESCRIPTION
There was a bug where if a custom command was provided, all environments
were enabled and using that command without being possible to disable
them.