### PR TITLE
SUP-10538 add severity option to alerts

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
@@ -18,9 +18,10 @@ package uk.gov.hmrc.alertconfig
 
 import spray.json.DefaultJsonProtocol
 import uk.gov.hmrc.alertconfig.HttpStatus.HttpStatusType
+import uk.gov.hmrc.alertconfig.AlertSeverity.AlertSeverityType
 
 
-case class HttpStatusThreshold(httpStatus: HttpStatusType, count: Int = 1)
+case class HttpStatusThreshold(httpStatus: HttpStatusType, count: Int = 1, severity: AlertSeverityType = AlertSeverity.critical)
 
 
 object HttpStatus extends Enumeration {
@@ -33,10 +34,19 @@ object HttpStatus extends Enumeration {
   val HTTP_STATUS_504 = Value(504)
 }
 
+object AlertSeverity extends Enumeration {
+  type AlertSeverityType = Value
+  val info = Value("Info")
+  val warning = Value("Warning")
+  val error = Value("Error")
+  val critical = Value("Critical")
+}
 
 object HttpStatusThresholdProtocol extends DefaultJsonProtocol {
 
   implicit val httpStatusFormat = jsonHttpStatusEnum(HttpStatus)
 
-  implicit val thresholdFormat = jsonFormat2(HttpStatusThreshold)
+  implicit val severityFormat = jsonSeverityEnum(AlertSeverity)
+
+  implicit val thresholdFormat = jsonFormat3(HttpStatusThreshold)
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
@@ -28,4 +28,13 @@ package object alertconfig {
       case something => throw DeserializationException(s"Expected a value from enum $enu instead of $something")
     }
   }
+
+  def jsonSeverityEnum(enu: AlertSeverity.type) = new JsonFormat[AlertSeverity.Value] {
+    def write(obj: AlertSeverity.AlertSeverityType) = JsString(obj.toString)
+
+    def read(json: JsValue) = json match {
+      case JsNumber(num) => AlertSeverity(num.toInt)
+      case something => throw DeserializationException(s"Expected a value from enum $enu instead of $something")
+    }
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -21,7 +21,7 @@ import java.io.FileNotFoundException
 import org.scalatest._
 import spray.json._
 import uk.gov.hmrc.alertconfig.HttpStatus._
-import uk.gov.hmrc.alertconfig.HttpStatusThreshold
+import uk.gov.hmrc.alertconfig.{HttpStatusThreshold, AlertSeverity}
 
 class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterEach {
 
@@ -85,17 +85,17 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
       assert(exception.getCause.isInstanceOf[FileNotFoundException])
     }
 
-    "build/configure http status threshold with given thresholds" in {
+    "build/configure http status threshold with given thresholds and severities" in {
 
       val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
-        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 2))
-        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 3))
+        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 2, AlertSeverity.warning))
+        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 3, AlertSeverity.error))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_504, 4)).build.get.parseJson.asJsObject.fields
 
       serviceConfig("httpStatusThresholds") shouldBe JsArray(
-        JsObject("httpStatus" -> JsNumber(502),"count" ->  JsNumber(2)),
-        JsObject("httpStatus" -> JsNumber(503),"count" ->  JsNumber(3)),
-        JsObject("httpStatus" -> JsNumber(504),"count" ->  JsNumber(4))
+        JsObject("httpStatus" -> JsNumber(502),"count" ->  JsNumber(2), "severity" -> JsString("Warning")),
+        JsObject("httpStatus" -> JsNumber(503),"count" ->  JsNumber(3), "severity" -> JsString("Error")),
+        JsObject("httpStatus" -> JsNumber(504),"count" ->  JsNumber(4), "severity" -> JsString("Critical"))
       )
     }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.alertconfig.builders
 
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import spray.json.{JsArray, JsString}
-import uk.gov.hmrc.alertconfig.{HttpStatus, HttpStatusThreshold, LogMessageThreshold}
+import uk.gov.hmrc.alertconfig.{AlertSeverity, HttpStatus, HttpStatusThreshold, LogMessageThreshold}
 import spray.json._
 
 
@@ -46,7 +46,7 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
 
     "return TeamAlertConfigBuilder with correct httpStatusThresholds" in {
 
-      val threshold1 = HttpStatusThreshold(HttpStatus.HTTP_STATUS_500, 19)
+      val threshold1 = HttpStatusThreshold(HttpStatus.HTTP_STATUS_500, 19, AlertSeverity.warning)
       val threshold2 = HttpStatusThreshold(HttpStatus.HTTP_STATUS_501, 20)
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
         .withHttpStatusThreshold(threshold1)
@@ -63,16 +63,20 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
       service1Config("httpStatusThresholds") shouldBe
         JsArray(
           JsObject("httpStatus" -> JsNumber(500),
-            "count" -> JsNumber(19)),
+            "count" -> JsNumber(19),
+            "severity" -> JsString("Warning")),
           JsObject("httpStatus" -> JsNumber(501),
-            "count" -> JsNumber(20))
+            "count" -> JsNumber(20),
+            "severity" -> JsString("Critical"))
         )
       service2Config("httpStatusThresholds") shouldBe
         JsArray(
           JsObject("httpStatus" -> JsNumber(500),
-            "count" -> JsNumber(19)),
+            "count" -> JsNumber(19),
+            "severity" -> JsString("Warning")),
           JsObject("httpStatus" -> JsNumber(501),
-            "count" -> JsNumber(20))
+            "count" -> JsNumber(20),
+            "severity" -> JsString("Critical"))
         )
 
     }


### PR DESCRIPTION
Extend HttpStatusThreshold to allow customisation of alert severity.
This will allow us to raise incidents in PagerDuty at different
severities to allow incidents to be routed differently based on the
severity