### PR TITLE
SUP-10538 refactor AlertSeverity class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 scala:
 - 2.11.6
 jdk:
-- oraclejdk8
+- openjdk8
 cache:
   directories:
     - '$HOME/.ivy2/cache'

--- a/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig
+
+object AlertSeverity extends Enumeration {
+  type AlertSeverityType = Value
+  val info = Value("info")
+  val warning = Value("warning")
+  val error = Value("error")
+  val critical = Value("critical")
+}
+

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
@@ -34,14 +34,6 @@ object HttpStatus extends Enumeration {
   val HTTP_STATUS_504 = Value(504)
 }
 
-object AlertSeverity extends Enumeration {
-  type AlertSeverityType = Value
-  val info = Value("Info")
-  val warning = Value("Warning")
-  val error = Value("Error")
-  val critical = Value("Critical")
-}
-
 object HttpStatusThresholdProtocol extends DefaultJsonProtocol {
 
   implicit val httpStatusFormat = jsonHttpStatusEnum(HttpStatus)

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -119,7 +119,7 @@ case class EnvironmentAlertBuilder(
 
   private def commandFor(service: String, environment: Environment): JsValue =
     if (enabledEnvironments.contains(environment))
-      command.getOrElse(JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team $service -e ${customEnvironmentNames(environment)}"))
+      command.getOrElse(JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team $service -e ${customEnvironmentNames(environment)}"))
     else
       JsString("/etc/sensu/handlers/noop.rb")
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -93,9 +93,9 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_504, 4)).build.get.parseJson.asJsObject.fields
 
       serviceConfig("httpStatusThresholds") shouldBe JsArray(
-        JsObject("httpStatus" -> JsNumber(502),"count" ->  JsNumber(2), "severity" -> JsString("Warning")),
-        JsObject("httpStatus" -> JsNumber(503),"count" ->  JsNumber(3), "severity" -> JsString("Error")),
-        JsObject("httpStatus" -> JsNumber(504),"count" ->  JsNumber(4), "severity" -> JsString("Critical"))
+        JsObject("httpStatus" -> JsNumber(502),"count" ->  JsNumber(2), "severity" -> JsString("warning")),
+        JsObject("httpStatus" -> JsNumber(503),"count" ->  JsNumber(3), "severity" -> JsString("error")),
+        JsObject("httpStatus" -> JsNumber(504),"count" ->  JsNumber(4), "severity" -> JsString("critical"))
       )
     }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -30,7 +30,7 @@ class AllEnvironmentAlertConfigBuilderSpec extends FunSuite with Matchers with B
 
   def defaultEnabledHandlerConfig(service: String, environment: Environment): JsObject =
     JsObject(
-      "command" -> JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team $service -e $environment"),
+      "command" -> JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team $service -e $environment"),
       "type" -> JsString("pipe"),
       "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
       "filter" -> JsString("occurrences"))

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -26,7 +26,7 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
       EnvironmentAlertBuilder("team-telemetry").alertConfigFor(Production) shouldBe
         "team-telemetry" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team team-telemetry -e aws_production"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team team-telemetry -e aws_production"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
             "filter" -> JsString("occurrences"))
@@ -46,7 +46,7 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
       EnvironmentAlertBuilder("infra").inIntegration().alertConfigFor(Integration) shouldBe
         "infra" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team infra -e aws_integration"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team infra -e aws_integration"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
             "filter" -> JsString("occurrences"))
@@ -76,7 +76,7 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
       EnvironmentAlertBuilder("txm-infra").inIntegration(customEnv="txm_integration").alertConfigFor(Integration) shouldBe
         "txm-infra" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team txm-infra -e txm_integration"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team txm-infra -e txm_integration"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
             "filter" -> JsString("occurrences"))
@@ -96,7 +96,7 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
       EnvironmentAlertBuilder("team-telemetry").inIntegration(Set(Ok, Warning, Critical, Unknown)).alertConfigFor(Integration) shouldBe
         "team-telemetry" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team team-telemetry -e aws_integration"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team team-telemetry -e aws_integration"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical"), JsString("unknown")),
             "filter" -> JsString("occurrences"))
@@ -106,7 +106,7 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
       EnvironmentAlertBuilder("infra").inManagement().alertConfigFor(Management) shouldBe
         "infra" ->
           JsObject(
-            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env.rb --team infra -e aws_management"),
+            "command" -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team infra -e aws_management"),
             "type" -> JsString("pipe"),
             "severities" ->  JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
             "filters" -> JsArray(JsString("occurrences"),JsString("kitchen_filter"),JsString("packer_filter")))

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -64,19 +64,19 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
         JsArray(
           JsObject("httpStatus" -> JsNumber(500),
             "count" -> JsNumber(19),
-            "severity" -> JsString("Warning")),
+            "severity" -> JsString("warning")),
           JsObject("httpStatus" -> JsNumber(501),
             "count" -> JsNumber(20),
-            "severity" -> JsString("Critical"))
+            "severity" -> JsString("critical"))
         )
       service2Config("httpStatusThresholds") shouldBe
         JsArray(
           JsObject("httpStatus" -> JsNumber(500),
             "count" -> JsNumber(19),
-            "severity" -> JsString("Warning")),
+            "severity" -> JsString("warning")),
           JsObject("httpStatus" -> JsNumber(501),
             "count" -> JsNumber(20),
-            "severity" -> JsString("Critical"))
+            "severity" -> JsString("critical"))
         )
 
     }


### PR DESCRIPTION
Update to use PagerDuty events api v2
Correct the severity names (pagerduty documents them as starting with
a capital letter but only accepts them as lower case!).
Also decided to refactor AlertSeverity class into it's own file as it
doesn't relate specifically to HttpStatusThreshold but other classes can
also use it
Also update travis to use openjdk as oraclejdk8 no longer works on
travis-ci