### PR TITLE
TEL-1253 Refactor team-telemetry-test to labs-team-telemetry

### DIFF
--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -83,8 +83,8 @@ class EnvironmentAlertBuilderSpec  extends WordSpec with Matchers with BeforeAnd
     }
 
     "create config with integration disabled" in {
-      EnvironmentAlertBuilder("team-telemetry-test").alertConfigFor(Integration) shouldBe
-        "team-telemetry-test" ->
+      EnvironmentAlertBuilder("labs-team-telemetry").alertConfigFor(Integration) shouldBe
+        "labs-team-telemetry" ->
           JsObject(
             "command" -> JsString("/etc/sensu/handlers/noop.rb"),
             "type" -> JsString("pipe"),


### PR DESCRIPTION
Consistent naming - treat as prefix for consistency.
Added labs version of team-telemetry-heartbeat so
these can be handled too when a test cluster is
stood up.