### PR TITLE
SUP-10805 add http 5xx threshold with severity

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThresholdSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThresholdSeverity.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig
+
+import spray.json.{DefaultJsonProtocol, JsonFormat, RootJsonFormat}
+import uk.gov.hmrc.alertconfig.AlertSeverity.AlertSeverityType
+
+case class Http5xxThresholdSeverity(count: Int = Int.MaxValue, severity: AlertSeverityType = AlertSeverity.critical)
+
+object Http5xxThresholdSeverityProtocol extends DefaultJsonProtocol {
+
+  implicit val severityFormat: JsonFormat[AlertSeverity.Value] = jsonSeverityEnum(AlertSeverity)
+
+  implicit val thresholdFormat: RootJsonFormat[Http5xxThresholdSeverity] = jsonFormat2(Http5xxThresholdSeverity)
+}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -40,6 +40,7 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
       config("handlers") shouldBe JsArray(JsString("h1"), JsString("h2"))
       config("exception-threshold") shouldBe JsNumber(2)
       config("5xx-threshold") shouldBe JsNumber(Int.MaxValue)
+      config("5xx-threshold-severity") shouldBe JsObject("count" -> JsNumber(Int.MaxValue),"severity" -> JsString("critical"))
       config("5xx-percent-threshold") shouldBe JsNumber(100)
       config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
       config("containerKillThreshold") shouldBe JsNumber(56)
@@ -98,6 +99,23 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
         JsObject("httpStatus" -> JsNumber(504),"count" ->  JsNumber(4), "severity" -> JsString("critical"))
       )
     }
+
+    "build/configure http 5xx threshold severity with given thresholds and severities" in {
+
+      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxThresholdSeverity(2, AlertSeverity.warning).build.get.parseJson.asJsObject.fields
+
+      serviceConfig("5xx-threshold-severity") shouldBe JsObject("count" ->  JsNumber(2), "severity" -> JsString("warning"))
+    }
+
+    "build/configure http 5xx threshold severity with given thresholds and unspecified severity" in {
+
+      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxThresholdSeverity(2).build.get.parseJson.asJsObject.fields
+
+      serviceConfig("5xx-threshold-severity") shouldBe JsObject("count" ->  JsNumber(2), "severity" -> JsString("critical"))
+    }
+
 
     "build/configure logMessageThresholds with given thresholds" in {
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.alertconfig.builders
 
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import spray.json.{JsArray, JsString}
-import uk.gov.hmrc.alertconfig.{AlertSeverity, HttpStatus, HttpStatusThreshold, LogMessageThreshold}
+import uk.gov.hmrc.alertconfig.{AlertSeverity, Http5xxThresholdSeverity, HttpStatus, HttpStatusThreshold, LogMessageThreshold}
 import spray.json._
 
 
@@ -38,9 +38,35 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
       alertConfigBuilder.handlers shouldBe Seq("noop")
       alertConfigBuilder.http5xxPercentThreshold shouldBe 100
       alertConfigBuilder.http5xxThreshold shouldBe Int.MaxValue
+      alertConfigBuilder.http5xxThresholdSeverity shouldBe Http5xxThresholdSeverity(Int.MaxValue,AlertSeverity.critical)
       alertConfigBuilder.totalHttpRequestThreshold shouldBe Int.MaxValue
       alertConfigBuilder.exceptionThreshold shouldBe 2
       alertConfigBuilder.containerKillThreshold shouldBe 1
+    }
+
+    "return TeamAlertConfigBuilder with correct http5xxThresholdSeverities" in {
+
+      val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
+        .withHttp5xxThresholdSeverity(19, AlertSeverity.warning)
+
+
+      alertConfigBuilder.services shouldBe Seq("service1", "service2")
+      val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
+
+      configs.size shouldBe 2
+      val service1Config = configs(0)
+      val service2Config = configs(1)
+
+      service1Config("5xx-threshold-severity") shouldBe
+        JsObject(
+          "count" -> JsNumber(19),
+          "severity" -> JsString("warning"))
+
+      service2Config("5xx-threshold-severity") shouldBe
+        JsObject(
+          "count" -> JsNumber(19),
+          "severity" -> JsString("warning"))
+
     }
 
 


### PR DESCRIPTION
Add new builder to alert-config-builder that allows microservice teams
to create 5xx threshold alerts with custom pagerduty severities