### PR TITLE
DDCNL-1721: Add generic Int for withHttpStatusThreshold

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,17 +23,18 @@ import uk.gov.hmrc.alertconfig.AlertSeverity.AlertSeverityType
 
 case class HttpStatusThreshold(httpStatus: HttpStatusType, count: Int = 1, severity: AlertSeverityType = AlertSeverity.critical)
 
-
-object HttpStatus extends Enumeration {
-
-  type HttpStatusType = Value
-  val HTTP_STATUS_429 = Value(429)
-  val HTTP_STATUS_499 = Value(499)
-  val HTTP_STATUS_500 = Value(500)
-  val HTTP_STATUS_501 = Value(501)
-  val HTTP_STATUS_502 = Value(502)
-  val HTTP_STATUS_503 = Value(503)
-  val HTTP_STATUS_504 = Value(504)
+object HttpStatus {
+  sealed trait HttpStatusType {
+    val status: Int
+  }
+  case class HTTP_STATUS(val status: Int) extends HttpStatusType
+  case object HTTP_STATUS_429 extends HTTP_STATUS(429)
+  case object HTTP_STATUS_499 extends HTTP_STATUS(499)
+  case object HTTP_STATUS_500 extends HTTP_STATUS(500)
+  case object HTTP_STATUS_501 extends HTTP_STATUS(501)
+  case object HTTP_STATUS_502 extends HTTP_STATUS(502)
+  case object HTTP_STATUS_503 extends HTTP_STATUS(503)
+  case object HTTP_STATUS_504 extends HTTP_STATUS(504)
 }
 
 object HttpStatusThresholdProtocol extends DefaultJsonProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
@@ -15,31 +15,29 @@
  */
 
 package uk.gov.hmrc.alertconfig
-
-import spray.json.DefaultJsonProtocol
-import uk.gov.hmrc.alertconfig.HttpStatus.HttpStatusType
+import spray.json.{DefaultJsonProtocol, JsNumber, JsValue, JsonFormat}
 import uk.gov.hmrc.alertconfig.AlertSeverity.AlertSeverityType
+import uk.gov.hmrc.alertconfig.HttpStatus.HTTP_STATUS
 
-
-case class HttpStatusThreshold(httpStatus: HttpStatusType, count: Int = 1, severity: AlertSeverityType = AlertSeverity.critical)
+case class HttpStatusThreshold(httpStatus: HTTP_STATUS, count: Int = 1, severity: AlertSeverityType = AlertSeverity.critical)
 
 object HttpStatus {
-  sealed trait HttpStatusType {
-    val status: Int
-  }
-  case class HTTP_STATUS(val status: Int) extends HttpStatusType
-  case object HTTP_STATUS_429 extends HTTP_STATUS(429)
-  case object HTTP_STATUS_499 extends HTTP_STATUS(499)
-  case object HTTP_STATUS_500 extends HTTP_STATUS(500)
-  case object HTTP_STATUS_501 extends HTTP_STATUS(501)
-  case object HTTP_STATUS_502 extends HTTP_STATUS(502)
-  case object HTTP_STATUS_503 extends HTTP_STATUS(503)
-  case object HTTP_STATUS_504 extends HTTP_STATUS(504)
+  case class HTTP_STATUS(status: Int)
+  val HTTP_STATUS_429: HTTP_STATUS = HTTP_STATUS(429)
+  val HTTP_STATUS_499: HTTP_STATUS = HTTP_STATUS(499)
+  val HTTP_STATUS_500: HTTP_STATUS = HTTP_STATUS(500)
+  val HTTP_STATUS_501: HTTP_STATUS = HTTP_STATUS(501)
+  val HTTP_STATUS_502: HTTP_STATUS = HTTP_STATUS(502)
+  val HTTP_STATUS_503: HTTP_STATUS = HTTP_STATUS(503)
+  val HTTP_STATUS_504: HTTP_STATUS = HTTP_STATUS(504)
 }
 
 object HttpStatusThresholdProtocol extends DefaultJsonProtocol {
 
-  implicit val httpStatusFormat = jsonHttpStatusEnum(HttpStatus)
+  implicit object httpStatusFormat extends JsonFormat[HTTP_STATUS] {
+    override def read(json: JsValue): HTTP_STATUS = HTTP_STATUS(IntJsonFormat.read(json))
+    override def write(obj: HTTP_STATUS): JsValue = JsNumber(obj.status)
+  }
 
   implicit val severityFormat = jsonSeverityEnum(AlertSeverity)
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/LogMessageThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
@@ -20,15 +20,6 @@ import spray.json.{DeserializationException, JsNumber, JsString, JsValue, JsonFo
 
 package object alertconfig {
 
-  def jsonHttpStatusEnum(enu: HttpStatus.type) = new JsonFormat[HttpStatus.HTTP_STATUS] {
-    def write(obj: HttpStatus.HTTP_STATUS) = JsNumber(obj.status)
-
-    def read(json: JsValue) = json match {
-      case JsNumber(num) => HttpStatus.HTTP_STATUS(num.toInt)
-      case something => throw DeserializationException(s"Expected a value from enum $enu instead of $something")
-    }
-  }
-
   def jsonSeverityEnum(enu: AlertSeverity.type) = new JsonFormat[AlertSeverity.Value] {
     def write(obj: AlertSeverity.AlertSeverityType) = JsString(obj.toString)
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import spray.json.{DeserializationException, JsNumber, JsString, JsValue, JsonFo
 
 package object alertconfig {
 
-  def jsonHttpStatusEnum(enu: HttpStatus.type) = new JsonFormat[HttpStatus.Value] {
-    def write(obj: HttpStatus.HttpStatusType) = JsNumber(obj.id)
+  def jsonHttpStatusEnum(enu: HttpStatus.type) = new JsonFormat[HttpStatus.HTTP_STATUS] {
+    def write(obj: HttpStatus.HTTP_STATUS) = JsNumber(obj.status)
 
     def read(json: JsValue) = json match {
-      case JsNumber(num) => HttpStatus(num.toInt)
+      case JsNumber(num) => HttpStatus.HTTP_STATUS(num.toInt)
       case something => throw DeserializationException(s"Expected a value from enum $enu instead of $something")
     }
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
See SUP-11085 for details.

Due to the use of reflection, No range check is done on the status in the model. The resulting exception was not helpful at all in alert-config. However, a new test will be in alert-config to enforce the correct range of statuses available.

This needs an update in aws-ami-base too:
https://github.com/hmrc/aws-ami-sensu-base/pull/310