### PR TITLE
DDCNL: removed bintray and updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 val libName = "alert-config-builder"
 
 lazy val library = Project(libName, file("."))
-  .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(
     majorVersion := 0,
-    makePublicallyAvailableOnBintray := true,
-    scalaVersion := "2.11.6",
+    isPublicArtefact := true,
+    scalaVersion := "2.12.14",
     scalacOptions ++= Seq(
       "-Xlint",
       "-target:jvm-1.8",

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -3,16 +3,16 @@ import sbt._
 object LibDependencies {
 
   val compile = Seq(
-    "org.scala-lang" % "scala-reflect" % "2.11.7",
-    "org.reflections" % "reflections" % "0.9.9-RC1",
-    "io.spray" %% "spray-json" % "1.3.5",
-    "org.yaml" % "snakeyaml" % "1.17"
+    "org.scala-lang" % "scala-reflect" % "2.12.14",
+    "org.reflections" % "reflections" % "0.9.12",
+    "io.spray" %% "spray-json" % "1.3.6",
+    "org.yaml" % "snakeyaml" % "1.29"
   )
 
 
   val test = Seq(
-    "org.json4s" %% "json4s-jackson" % "3.6.4" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+    "org.json4s" %% "json4s-jackson" % "4.0.1" % "test",
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % "test",
     "org.pegdown" % "pegdown" % "1.6.0" % "test"
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,8 @@
-resolvers += Resolver.url("hmrc-sbt-plugin-releases",
-  url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
+resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.3.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/LogMessageThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.alertconfig.builders
 
-import spray.json.{JsArray, JsNull, JsObject, JsString, JsValue}
+import spray.json.{JsArray, JsObject, JsString, JsValue}
 
 sealed trait Severity {
   override def toString: String = this.getClass.getSimpleName.toLowerCase.replace("$", "")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.io.FileNotFoundException
 import org.scalatest._
 import spray.json._
 import uk.gov.hmrc.alertconfig.HttpStatus._
-import uk.gov.hmrc.alertconfig.{AlertSeverity, Http5xxThreshold, HttpAbsolutePercentSplitThreshold, HttpStatusThreshold}
+import uk.gov.hmrc.alertconfig.{AlertSeverity, HttpAbsolutePercentSplitThreshold, HttpStatusThreshold}
 
 class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterEach {
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 HM Revenue & Customs
+ * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package uk.gov.hmrc.alertconfig.builders
 
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import spray.json.{JsArray, JsString}
-import uk.gov.hmrc.alertconfig.{AlertSeverity, Http5xxThreshold, HttpAbsolutePercentSplitThreshold, HttpStatus, HttpStatusThreshold, LogMessageThreshold}
+import uk.gov.hmrc.alertconfig.{AlertSeverity, Http5xxThreshold, HttpAbsolutePercentSplitThreshold, HttpStatus, HttpStatusThreshold}
 import spray.json._
 import uk.gov.hmrc.alertconfig.HttpStatus.HTTP_STATUS
 


### PR DESCRIPTION
When used in alert-config it fails with:

```
[warn] one warning found
[info] ConfigsSpec:
[info] uk.gov.hmrc.alertconfig.ConfigsSpec *** ABORTED ***
[info]   java.lang.AssertionError: assertion failed: PortalRehomingAccount$
[info]   at scala.reflect.internal.SymbolTable.throwAssertionError(SymbolTable.scala:185)
[info]   at scala.reflect.internal.Symbols$Symbol.completeInfo(Symbols.scala:1525)
[info]   at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1514)
[info]   at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$7.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:203)
[info]   at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.$anonfun$info$1(SynchronizedSymbols.scala:158)
[info]   at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info(SynchronizedSymbols.scala:149)
[info]   at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.info$(SynchronizedSymbols.scala:158)
[info]   at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$7.info(SynchronizedSymbols.scala:203)
[info]   at scala.reflect.internal.Symbols$Symbol.initialize(Symbols.scala:1698)
[info]   at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol.getFlag(SynchronizedSymbols.scala:153)
```