### PR TITLE
TEL-3590 Adds severity to exception threshold alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ dist
 .cache
 .sbt
 .ivy2
-    
+.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,5 @@ lazy val library = Project(libName, file("."))
     majorVersion := 0,
     isPublicArtefact := true,
     scalaVersion := "2.11.6",
-    scalacOptions ++= Seq(
-      "-Xlint",
-      "-target:jvm-1.8",
-      "-Xmax-classfile-name", "100",
-      "-encoding", "UTF-8"
-    )
-  )
-  .settings(
-    parallelExecution in Test := false,
-    fork in Test := false
   )
   .settings(libraryDependencies ++= LibDependencies.compile ++ LibDependencies.test)

--- a/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/AlertSeverity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/ExceptionThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/ExceptionThreshold.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.alertconfig
 
-import spray.json.DefaultJsonProtocol
+import spray.json.{DefaultJsonProtocol, JsonFormat, RootJsonFormat}
+import uk.gov.hmrc.alertconfig.AlertSeverity.AlertSeverityType
 
-// By default we alert if the count of messages is >= threshold. If lessThanMode is set we alert if < threshold
-case class LogMessageThreshold(message: String, count: Int, lessThanMode: Boolean = false)
+case class ExceptionThreshold(count: Int = 2, severity: AlertSeverityType = AlertSeverity.critical)
 
-object LogMessageThresholdProtocol extends DefaultJsonProtocol {
+object ExceptionThresholdProtocol extends DefaultJsonProtocol {
 
-  implicit val format = jsonFormat3(LogMessageThreshold)
+  implicit val severityFormat: JsonFormat[AlertSeverity.Value] = jsonSeverityEnum(AlertSeverity)
+
+  implicit val thresholdFormat: RootJsonFormat[ExceptionThreshold] = jsonFormat2(ExceptionThreshold)
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitDownstreamHodThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitDownstreamHodThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitDownstreamServiceThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitDownstreamServiceThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpAbsolutePercentSplitThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpMethod.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpMethod.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatus.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatus.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusPercentThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/HttpStatusThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/MetricsThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/MetricsThreshold.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/ObjectScanner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ trait Builder[T] {
 case class AlertConfigBuilder(serviceName: String,
                               handlers: Seq[String] = Seq("noop"),
                               errorsLoggedThreshold: Int = Int.MaxValue,
-                              exceptionThreshold: Int = 2,
+                              exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
                               http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
                               http5xxPercentThreshold: Double = 100.0,
                               httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold] = Nil,
@@ -57,7 +57,7 @@ case class AlertConfigBuilder(serviceName: String,
 
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int) = this.copy(errorsLoggedThreshold = errorsLoggedThreshold)
 
-  def withExceptionThreshold(exceptionThreshold: Int) = this.copy(exceptionThreshold = exceptionThreshold)
+  def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity))
 
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
 
@@ -111,7 +111,7 @@ case class AlertConfigBuilder(serviceName: String,
              |"app": "$serviceName.$serviceDomain",
              |"handlers": ${handlers.toJson.compactPrint},
              |"errors-logged-threshold":$errorsLoggedThreshold,
-             |"exception-threshold":$exceptionThreshold,
+             |"exception-threshold":${exceptionThreshold.toJson(ExceptionThresholdProtocol.thresholdFormat).compactPrint},
              |"5xx-threshold":${http5xxThreshold.toJson(Http5xxThresholdProtocol.thresholdFormat).compactPrint},
              |"5xx-percent-threshold":$http5xxPercentThreshold,
              |"containerKillThreshold" : $containerKillThreshold,
@@ -159,7 +159,7 @@ case class AlertConfigBuilder(serviceName: String,
 case class TeamAlertConfigBuilder(
                                    services: Seq[String], handlers: Seq[String] = Seq("noop"),
                                    errorsLoggedThreshold: Int = Int.MaxValue,
-                                   exceptionThreshold: Int = 2,
+                                   exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
                                    http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
                                    http5xxPercentThreshold: Double = 100.0,
                                    httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold] = Nil,
@@ -179,7 +179,7 @@ case class TeamAlertConfigBuilder(
 
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int) = this.copy(errorsLoggedThreshold = errorsLoggedThreshold)
 
-  def withExceptionThreshold(exceptionThreshold: Int) = this.copy(exceptionThreshold = exceptionThreshold)
+  def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity))
 
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/logging/Logger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/ObjectScannerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
 
       config("app") shouldBe JsString("service1.domain.zone.1")
       config("handlers") shouldBe JsArray(JsString("h1"), JsString("h2"))
-      config("exception-threshold") shouldBe JsNumber(2)
+      config("exception-threshold") shouldBe JsObject("count" -> JsNumber(2), "severity" -> JsString("critical"))
       config("5xx-threshold") shouldBe JsObject("count" -> JsNumber(Int.MaxValue), "severity" -> JsString("critical"))
       config("5xx-percent-threshold") shouldBe JsNumber(100)
       config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
@@ -301,7 +301,25 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
       .withExceptionThreshold(threshold).build.get.parseJson.asJsObject.fields
 
-    serviceConfig("exception-threshold") shouldBe JsNumber(threshold)
+    val expected = JsObject(
+      "severity" -> JsString("critical"),
+      "count" -> JsNumber(12)
+    )
+
+    serviceConfig("exception-threshold") shouldBe expected
+  }
+
+  "build/configure ExceptionThreshold with optional parameter severity" in {
+    val threshold = 12
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      .withExceptionThreshold(threshold, AlertSeverity.warning).build.get.parseJson.asJsObject.fields
+
+    val expected = JsObject(
+      "severity" -> JsString("warning"),
+      "count" -> JsNumber(12)
+    )
+
+    serviceConfig("exception-threshold") shouldBe expected
   }
 
   "build/configure ErrorsLoggedThreshold with required parameters" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -303,7 +303,7 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
 
     val expected = JsObject(
       "severity" -> JsString("critical"),
-      "count" -> JsNumber(12)
+      "count" -> JsNumber(threshold)
     )
 
     serviceConfig("exception-threshold") shouldBe expected
@@ -316,7 +316,7 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
 
     val expected = JsObject(
       "severity" -> JsString("warning"),
-      "count" -> JsNumber(12)
+      "count" -> JsNumber(threshold)
     )
 
     serviceConfig("exception-threshold") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/EnvironmentAlertBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.alertconfig.builders
 
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
-import spray.json.{JsArray, JsString}
+import spray.json.{JsArray, JsString, JsObject}
 import uk.gov.hmrc.alertconfig._
 import spray.json._
 import uk.gov.hmrc.alertconfig.HttpStatus.HTTP_STATUS
@@ -39,7 +39,7 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
       alertConfigBuilder.http5xxPercentThreshold shouldBe 100
       alertConfigBuilder.http5xxThreshold shouldBe Http5xxThreshold(Int.MaxValue,AlertSeverity.critical)
       alertConfigBuilder.totalHttpRequestThreshold shouldBe Int.MaxValue
-      alertConfigBuilder.exceptionThreshold shouldBe 2
+      alertConfigBuilder.exceptionThreshold shouldBe ExceptionThreshold(2, AlertSeverity.critical)
       alertConfigBuilder.containerKillThreshold shouldBe 1
       alertConfigBuilder.averageCPUThreshold shouldBe Int.MaxValue
       alertConfigBuilder.httpStatusThresholds shouldBe List()
@@ -171,7 +171,7 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
     "return TeamAlertConfigBuilder with correct ExceptionThreshold" in {
       val threshold = 13
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
-        .withExceptionThreshold(threshold)
+        .withExceptionThreshold(threshold, AlertSeverity.warning)
 
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
       val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
@@ -180,8 +180,14 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      service1Config("exception-threshold") shouldBe JsNumber(threshold)
-      service2Config("exception-threshold") shouldBe JsNumber(threshold)
+      service1Config("exception-threshold") shouldBe JsObject(
+        "count" -> JsNumber(threshold),
+        "severity" -> JsString("warning")
+      )
+      service2Config("exception-threshold") shouldBe JsObject(
+        "count" -> JsNumber(threshold),
+        "severity" -> JsString("warning")
+      )
     }
 
     "return TeamAlertConfigBuilder with correct AverageCPUThreshold" in {


### PR DESCRIPTION
What we have done
--

1. Added new value object for configuring exception threshold alerts to have an overrideable severity

References
--

1. [Spreadsheet of our progress](https://docs.google.com/spreadsheets/d/1bZtS0rAmuZdGZrKQzoe_2FF1iOs1_S8Zm17QUG5t_wk/edit#gid=0)
2. [Flowchart of our plan of action](https://app.diagrams.net/#G1dDuEnL8w3aZonC00vdKzcotRUorsHROE)
3. https://jira.tools.tax.service.gov.uk/browse/TEL-3590

Evidence of work
--

1. Automated tests

Risks
--

1. Me no Scala good
2. Are there other functions that need this treatment?

Next steps
--

1. Update the alert-config repo to use the new version of this library
2. Update the alerts that are to have custom severity
3. Deploy+test

Collaborators
--

1. Co-authored-by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>