### PR TITLE
TEL-3590 Adds value object Http5xxPercentThresholdProtocol

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/Http5xxPercentThreshold.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig
+
+import spray.json.{DefaultJsonProtocol, JsonFormat, RootJsonFormat}
+import uk.gov.hmrc.alertconfig.AlertSeverity.AlertSeverityType
+
+case class Http5xxPercentThreshold(percentage: Double = 100.0, severity: AlertSeverityType = AlertSeverity.critical)
+
+object Http5xxPercentThresholdProtocol extends DefaultJsonProtocol {
+  implicit val severityFormat = jsonSeverityEnum(AlertSeverity)
+  implicit val thresholdFormat = jsonFormat2(Http5xxPercentThreshold)
+}

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilder.scala
@@ -35,7 +35,7 @@ case class AlertConfigBuilder(serviceName: String,
                               errorsLoggedThreshold: Int = Int.MaxValue,
                               exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
                               http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
-                              http5xxPercentThreshold: Double = 100.0,
+                              http5xxPercentThreshold: Http5xxPercentThreshold = Http5xxPercentThreshold(100.0),
                               httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold] = Nil,
                               httpAbsolutePercentSplitDownstreamServiceThresholds: Seq[HttpAbsolutePercentSplitDownstreamServiceThreshold] = Nil,
                               httpAbsolutePercentSplitDownstreamHodThresholds: Seq[HttpAbsolutePercentSplitDownstreamHodThreshold] = Nil,
@@ -61,7 +61,7 @@ case class AlertConfigBuilder(serviceName: String,
 
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
 
-  def withHttp5xxPercentThreshold(http5xxPercentThreshold: Double) = this.copy(http5xxPercentThreshold = http5xxPercentThreshold)
+  def withHttp5xxPercentThreshold(percentThreshold: Double, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity))
 
   def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) = this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 
@@ -113,7 +113,7 @@ case class AlertConfigBuilder(serviceName: String,
              |"errors-logged-threshold":$errorsLoggedThreshold,
              |"exception-threshold":${exceptionThreshold.toJson(ExceptionThresholdProtocol.thresholdFormat).compactPrint},
              |"5xx-threshold":${http5xxThreshold.toJson(Http5xxThresholdProtocol.thresholdFormat).compactPrint},
-             |"5xx-percent-threshold":$http5xxPercentThreshold,
+             |"5xx-percent-threshold":${http5xxPercentThreshold.toJson(Http5xxPercentThresholdProtocol.thresholdFormat).compactPrint},
              |"containerKillThreshold" : $containerKillThreshold,
              |"httpStatusThresholds" : ${httpStatusThresholds.toJson.compactPrint},
              |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.toJson.compactPrint},
@@ -161,7 +161,7 @@ case class TeamAlertConfigBuilder(
                                    errorsLoggedThreshold: Int = Int.MaxValue,
                                    exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
                                    http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
-                                   http5xxPercentThreshold: Double = 100.0,
+                                   http5xxPercentThreshold: Http5xxPercentThreshold = Http5xxPercentThreshold(100.0),
                                    httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold] = Nil,
                                    httpAbsolutePercentSplitDownstreamServiceThresholds: Seq[HttpAbsolutePercentSplitDownstreamServiceThreshold] = Nil,
                                    httpAbsolutePercentSplitDownstreamHodThresholds: Seq[HttpAbsolutePercentSplitDownstreamHodThreshold] = Nil,
@@ -183,7 +183,7 @@ case class TeamAlertConfigBuilder(
 
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
 
-  def withHttp5xxPercentThreshold(percentThreshold: Double) = this.copy(http5xxPercentThreshold = percentThreshold)
+  def withHttp5xxPercentThreshold(percentThreshold: Double, severity: AlertSeverityType = AlertSeverity.critical) = this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity))
 
   def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) = this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/AlertConfigBuilderSpec.scala
@@ -39,7 +39,10 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
       config("handlers") shouldBe JsArray(JsString("h1"), JsString("h2"))
       config("exception-threshold") shouldBe JsObject("count" -> JsNumber(2), "severity" -> JsString("critical"))
       config("5xx-threshold") shouldBe JsObject("count" -> JsNumber(Int.MaxValue), "severity" -> JsString("critical"))
-      config("5xx-percent-threshold") shouldBe JsNumber(100)
+      config("5xx-percent-threshold") shouldBe JsObject(
+        "severity" -> JsString("critical"),
+        "percentage" -> JsNumber(100)
+      )
       config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
       config("containerKillThreshold") shouldBe JsNumber(56)
       config("average-cpu-threshold") shouldBe JsNumber(Int.MaxValue)
@@ -335,7 +338,10 @@ class AlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAfterE
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold).build.get.parseJson.asJsObject.fields
 
-    serviceConfig("5xx-percent-threshold") shouldBe JsNumber(threshold)
+    serviceConfig("5xx-percent-threshold") shouldBe JsObject(
+      "severity" -> JsString("critical"),
+      "percentage" -> JsNumber(threshold)
+    )
   }
 
   "build/configure averageCPUThreshold with required parameters" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -36,7 +36,7 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
 
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
       alertConfigBuilder.handlers shouldBe Seq("noop")
-      alertConfigBuilder.http5xxPercentThreshold shouldBe 100
+      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(100, AlertSeverity.critical)
       alertConfigBuilder.http5xxThreshold shouldBe Http5xxThreshold(Int.MaxValue,AlertSeverity.critical)
       alertConfigBuilder.totalHttpRequestThreshold shouldBe Int.MaxValue
       alertConfigBuilder.exceptionThreshold shouldBe ExceptionThreshold(2, AlertSeverity.critical)
@@ -164,8 +164,14 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      service1Config("5xx-percent-threshold") shouldBe JsNumber(threshold)
-      service2Config("5xx-percent-threshold") shouldBe JsNumber(threshold)
+      service1Config("5xx-percent-threshold") shouldBe JsObject(
+        "severity" -> JsString("critical"),
+        "percentage" -> JsNumber(threshold)
+      )
+      service2Config("5xx-percent-threshold") shouldBe JsObject(
+        "severity" -> JsString("critical"),
+        "percentage" -> JsNumber(threshold)
+      )
     }
 
     "return TeamAlertConfigBuilder with correct ExceptionThreshold" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -340,6 +340,7 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
         "severity" -> JsString("warning")
       )
     }
+
     "return TeamAlertConfigBuilder with correct logMessageThresholds" in {
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builders/TeamAlertConfigBuilderSpec.scala
@@ -47,6 +47,13 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
       alertConfigBuilder.httpAbsolutePercentSplitThresholds shouldBe List()
     }
 
+    "return TeamAlertConfigBuilder with correct 5xxPercentThreshold" in {
+      val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
+        .withHttp5xxPercentThreshold(19.2, AlertSeverity.warning)
+
+      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(19.2, AlertSeverity.warning)
+    }
+
     "return TeamAlertConfigBuilder with correct handlers" in {
       val handlers = Seq("a", "b")
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
@@ -318,6 +325,21 @@ class TeamAlertConfigBuilderSpec extends WordSpec with Matchers with BeforeAndAf
       service2Config("total-http-request-threshold") shouldBe JsNumber(requestThreshold)
     }
 
+    "return TeamAlertConfigBuilder with correct withHttp5xxPercentThreshold" in {
+      val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1"))
+        .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
+        .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
+        .withHttp5xxPercentThreshold(12.2, AlertSeverity.warning)
+
+      alertConfigBuilder.services shouldBe Seq("service1")
+      val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
+      val service1Config: Map[String, JsValue] = configs(0)
+
+      service1Config("5xx-percent-threshold") shouldBe JsObject(
+        "percentage" -> JsNumber(12.2),
+        "severity" -> JsString("warning")
+      )
+    }
     "return TeamAlertConfigBuilder with correct logMessageThresholds" in {
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)


### PR DESCRIPTION
What we have done
--

Made 5xx %age thresholds have configurable severity

References
--

1. https://jira.tools.tax.service.gov.uk/browse/TEL-3590
2. https://docs.google.com/spreadsheets/d/1bZtS0rAmuZdGZrKQzoe_2FF1iOs1_S8Zm17QUG5t_wk/edit#gid=0

Evidence of Work
--

1. Automated tests

Next steps
--

1. Update alert-config repo to set the threshold severity where appropriate

Risks
--

None known

Collaborators
--

Co-authored-by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
