### PR TITLE
TEL-3810 Add config builder for 5xx status rate increase alerts

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -31,6 +31,7 @@ case class AlertConfigBuilder(
   handlers                                           : Seq[String]                                             = Seq("noop"),
   errorsLoggedThreshold                              : Int                                                     = Int.MaxValue,
   exceptionThreshold                                 : ExceptionThreshold                                      = ExceptionThreshold(),
+  http5xxRateIncrease                                : Seq[Http5xxRateIncrease]                                = Nil,
   http5xxThreshold                                   : Http5xxThreshold                                        = Http5xxThreshold(),
   http5xxPercentThreshold                            : Http5xxPercentThreshold                                 = Http5xxPercentThreshold(100.0),
   httpAbsolutePercentSplitThresholds                 : Seq[HttpAbsolutePercentSplitThreshold]                  = Nil,
@@ -83,6 +84,9 @@ case class AlertConfigBuilder(
 
   def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
+
+  def withHttp5xxRateIncrease(rateIncrease: Http5xxRateIncrease) =
+    this.copy(http5xxRateIncrease = http5xxRateIncrease :+ rateIncrease)
 
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
@@ -140,6 +144,7 @@ case class AlertConfigBuilder(
              |"httpTrafficThresholds" : ${httpTrafficThresholds.toJson.compactPrint},
              |"httpStatusThresholds" : ${httpStatusThresholds.toJson.compactPrint},
              |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.toJson.compactPrint},
+             |"http5xxRateIncrease" : ${printSeq(http5xxRateIncrease)(Http5xxRateIncreaseProtocol.rateIncreaseFormat)},
              |"metricsThresholds" : ${printSeq(metricsThresholds)(MetricsThresholdProtocol.thresholdFormat)},
              |"total-http-request-threshold": $totalHttpRequestThreshold,
              |"log-message-thresholds" : $buildLogMessageThresholdsJson,
@@ -187,9 +192,10 @@ case class TeamAlertConfigBuilder(
                                    httpAbsolutePercentSplitDownstreamServiceThresholds: Seq[HttpAbsolutePercentSplitDownstreamServiceThreshold] = Nil,
                                    httpAbsolutePercentSplitDownstreamHodThresholds    : Seq[HttpAbsolutePercentSplitDownstreamHodThreshold]     = Nil,
                                    containerKillThreshold                             : Int                                                     = 1,
-                                   httpTrafficThresholds                              : Seq[HttpTrafficThreshold]                           = Nil,
+                                   httpTrafficThresholds                              : Seq[HttpTrafficThreshold]                               = Nil,
                                    httpStatusThresholds                               : Seq[HttpStatusThreshold]                                = Nil,
                                    httpStatusPercentThresholds                        : Seq[HttpStatusPercentThreshold]                         = Nil,
+                                   http5xxRateIncrease                                : Seq[Http5xxRateIncrease]                                = Nil,
                                    metricsThresholds                                  : Seq[MetricsThreshold]                                   = Nil,
                                    logMessageThresholds                               : Seq[LogMessageThreshold]                                = Nil,
                                    totalHttpRequestThreshold                          : Int                                                     = Int.MaxValue,
@@ -233,6 +239,9 @@ case class TeamAlertConfigBuilder(
   def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
+  def withHttp5xxRateIncrease(rateIncrease: Http5xxRateIncrease) =
+    this.copy(http5xxRateIncrease = http5xxRateIncrease :+ rateIncrease)
+
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
 
@@ -254,6 +263,7 @@ case class TeamAlertConfigBuilder(
         handlers,
         errorsLoggedThreshold,
         exceptionThreshold,
+        http5xxRateIncrease,
         http5xxThreshold,
         http5xxPercentThreshold,
         httpAbsolutePercentSplitThresholds,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5XXRateIncrease.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5XXRateIncrease.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder
+
+import spray.json.{DefaultJsonProtocol, JsonFormat}
+
+case class Http5xxRateIncrease(
+                                name: String,
+                                simple_threshold: Int,
+                                complex_threshold: Int
+                              )
+
+object Http5xxRateIncreaseProtocol extends DefaultJsonProtocol {
+  implicit val rateIncreaseFormat: JsonFormat[Http5xxRateIncrease] = jsonFormat3(Http5xxRateIncrease)
+}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -197,6 +197,18 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       serviceConfig("absolute-percentage-split-threshold") shouldBe expected
     }
 
+    "build/configure metrics rate increase" in {
+      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxRateIncrease(Http5xxRateIncrease(name = "alert_custom_name_1", simple_threshold = 10, complex_threshold = 100))
+        .withHttp5xxRateIncrease(Http5xxRateIncrease(name = "alert_custom_name_2", simple_threshold = 20, complex_threshold = 200))
+        .build.get.parseJson.asJsObject.fields
+
+      serviceConfig("http5xxRateIncrease") shouldBe JsArray(
+        JsObject("name" -> JsString("alert_custom_name_1"), "simple_threshold" -> JsNumber(10), "complex_threshold" -> JsNumber(100)),
+        JsObject("name" -> JsString("alert_custom_name_2"), "simple_threshold" -> JsNumber(20), "complex_threshold" -> JsNumber(200)),
+      )
+    }
+
     "build/configure metrics threshold with given warning and critical levels" in {
       val query = "some_function(over.some.query.for.anything.like*)"
       val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))


### PR DESCRIPTION
The model inclouds a name field which is not required for dynamic alerts of this sort. But is going to help us during the implementation of the plugin and testing it with different combinations of thresholds.
Based on the outcome of testing different thresholds, we might be able to provide default values for them in follow-up PRs