### PR TITLE
TEL-3818 First pass at removing INFO and ERROR severities

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
@@ -18,8 +18,6 @@ package uk.gov.hmrc.alertconfig.builder
 
 sealed trait AlertSeverity
 object AlertSeverity {
-  object Info     extends AlertSeverity { override def toString: String = "info"     }
   object Warning  extends AlertSeverity { override def toString: String = "warning"  }
-  object Error    extends AlertSeverity { override def toString: String = "error"    }
   object Critical extends AlertSeverity { override def toString: String = "critical" }
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/package.scala
@@ -25,7 +25,7 @@ package object builder {
       JsString(obj.toString)
 
     override def read(json: JsValue): AlertSeverity =
-      Seq(AlertSeverity.Info, AlertSeverity.Warning, AlertSeverity.Error, AlertSeverity.Critical)
+      Seq(AlertSeverity.Warning, AlertSeverity.Critical)
         .find(_.toString == json.toString)
         .getOrElse(deserializationError("Invalid AlertSeverity"))
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -105,12 +105,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     "build/configure http status threshold with given thresholds and severities" in {
       val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_502, 2, AlertSeverity.Warning, HttpMethod.Post))
-        .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_503, 3, AlertSeverity.Error, HttpMethod.Get))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_504, 4)).build.get.parseJson.asJsObject.fields
 
       serviceConfig("httpStatusThresholds") shouldBe JsArray(
         JsObject("httpStatus" -> JsNumber(502), "count" -> JsNumber(2), "severity" -> JsString("warning"), "httpMethod" -> JsString("POST")),
-        JsObject("httpStatus" -> JsNumber(503), "count" -> JsNumber(3), "severity" -> JsString("error"), "httpMethod" -> JsString("GET")),
         JsObject("httpStatus" -> JsNumber(504), "count" -> JsNumber(4), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"))
       )
     }
@@ -127,12 +125,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     "build/configure http status percent threshold with given thresholds and severities" in {
       val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post))
-        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_503, 3.3, AlertSeverity.Error, HttpMethod.Get))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_504, 4.4)).build.get.parseJson.asJsObject.fields
 
       serviceConfig("httpStatusPercentThresholds") shouldBe JsArray(
         JsObject("httpStatus" -> JsNumber(502), "percentage" -> JsNumber(2.2), "severity" -> JsString("warning"), "httpMethod" -> JsString("POST")),
-        JsObject("httpStatus" -> JsNumber(503), "percentage" -> JsNumber(3.3), "severity" -> JsString("error"), "httpMethod" -> JsString("GET")),
         JsObject("httpStatus" -> JsNumber(504), "percentage" -> JsNumber(4.4), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"))
       )
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -70,7 +70,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val hysteresis = 1.2
       val spikes = 2
       val filter = "status:200"
-      val severity = AlertSeverity.Info
+      val severity = AlertSeverity.Warning
 
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
         .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(percent, crossover, absolute, hysteresis, spikes, filter, severity))
@@ -102,7 +102,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val spikes = 2
       val filter = "status:200"
       val target = "something.invalid"
-      val severity = AlertSeverity.Info
+      val severity = AlertSeverity.Warning
 
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
         .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(percent, crossover, absolute, hysteresis, spikes, filter, target, severity))
@@ -135,7 +135,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val spikes = 2
       val filter = "status:200"
       val target = "hod-endpoint"
-      val severity = AlertSeverity.Info
+      val severity = AlertSeverity.Warning
 
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
         .withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(percent, crossover, absolute, hysteresis, spikes, filter, target, severity))


### PR DESCRIPTION
What did we do?
--

1. Removed any references to `Info` or `Error` severities so that they cannot be used in `alert-config` repo

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-3818

Evidence of work
--

* https://build.tax.service.gov.uk/job/PlatOps/job/Libraries/job/alert-config-builder/67
* https://build.tax.service.gov.uk/job/Telemetry/job/alert-config-pr-builder/259

Next Steps
--

1. Merge, get new version number `1.7.0` and update `alert-config` repo

Risks
--

1. Minimal, all the PR checks and tests pass

Collaboration
--

Co-authored-by: Rizina Khatun <66684341+rizinaa99@users.noreply.github.com>