### PR TITLE
TEL-4160 Helper for getting environment

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -39,6 +39,19 @@ object Environment {
   object ExternalTest extends Environment
   object Management   extends Environment
   object Production   extends Environment
+
+  def get(env: String): Environment = {
+    env.toLowerCase.trim.replaceAll(" ", "") match {
+      case "integration" => Integration
+      case "development" => Development
+      case "qa" => Qa
+      case "staging" => Staging
+      case "externaltest" => ExternalTest
+      case "management" => Management
+      case "production" => Production
+    }
+  }
+
 }
 
 object AllEnvironmentAlertConfigBuilder {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
@@ -118,7 +118,6 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
             "filters" -> JsArray(JsString("occurrences"), JsString("kitchen_filter"), JsString("packer_filter")))
     }
 
-
     "create config with development enabled with custom severities" in {
       EnvironmentAlertBuilder("team-telemetry").inDevelopment(Set(Severity.Ok, Severity.Warning, Severity.Critical, Severity.Unknown)).alertConfigFor(Environment.Development) shouldBe
         "team-telemetry" ->
@@ -169,4 +168,28 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
             "filter" -> JsString("occurrences"))
     }
   }
+
+  "Environment" when {
+    "using the get function" should {
+      "return specified environment" in {
+        Environment.get("integration") shouldBe Environment.Integration
+        Environment.get("development") shouldBe Environment.Development
+        Environment.get("qa") shouldBe Environment.Qa
+        Environment.get("staging") shouldBe Environment.Staging
+        Environment.get("externaltest") shouldBe Environment.ExternalTest
+        Environment.get("management") shouldBe Environment.Management
+        Environment.get("production") shouldBe Environment.Production
+      }
+      "work ignoring case" in {
+        Environment.get("PrOdUcTiOn") shouldBe Environment.Production
+      }
+      "work ignoring whitespace" in {
+        Environment.get("external test") shouldBe Environment.ExternalTest
+      }
+      "work ignoring any padded whitespace" in {
+        Environment.get("  production  ") shouldBe Environment.Production
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
### Changes
* Added new `Environment.get` function
* Function take a `String` and returns an `Environment` object representing the specified environment for use in other places in the `alert-config` repo

Co-authored-by: Gavin Davies <gavD@users.noreply.github.com>