### PR TITLE
TEL-4145 Permits HttpTrafficThreshold to target an alerting platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,6 @@ lazy val library = Project("alert-config-builder", file("."))
   .settings(
     majorVersion := 1,
     isPublicArtefact := true,
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.12",
   )
   .settings(libraryDependencies ++= LibDependencies.compile ++ LibDependencies.test)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
@@ -21,7 +21,8 @@ case class HttpStatusThreshold(
   httpStatus: HttpStatus.HTTP_STATUS,
   count     : Int           = 1,
   severity  : AlertSeverity = AlertSeverity.Critical,
-  httpMethod: HttpMethod    = HttpMethod.All
+  httpMethod: HttpMethod    = HttpMethod.All,
+  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
 )
 
 object HttpStatusThresholdProtocol {
@@ -31,6 +32,6 @@ object HttpStatusThresholdProtocol {
     implicit val hsf: JsonFormat[HttpStatus.HTTP_STATUS] = httpStatusFormat
     implicit val asf: JsonFormat[AlertSeverity]          = alertSeverityFormat
     implicit val hmf: JsonFormat[HttpMethod]             = httpMethodFormat
-    jsonFormat4(HttpStatusThreshold)
+    jsonFormat5(HttpStatusThreshold)
   }
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -108,8 +108,19 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_504, 4)).build.get.parseJson.asJsObject.fields
 
       serviceConfig("httpStatusThresholds") shouldBe JsArray(
-        JsObject("httpStatus" -> JsNumber(502), "count" -> JsNumber(2), "severity" -> JsString("warning"), "httpMethod" -> JsString("POST")),
-        JsObject("httpStatus" -> JsNumber(504), "count" -> JsNumber(4), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"))
+        JsObject("httpStatus" -> JsNumber(502), "count" -> JsNumber(2), "severity" -> JsString("warning"), "httpMethod" -> JsString("POST"), "alertingPlatform" -> JsString("Sensu")),
+        JsObject("httpStatus" -> JsNumber(504), "count" -> JsNumber(4), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"), "alertingPlatform" -> JsString("Sensu"))
+      )
+    }
+
+    "build/configure http status threshold with given thresholds and severities and targeting multiple alerting platforms" in {
+      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_502, 2, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana))
+        .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_504, 4)).build.get.parseJson.asJsObject.fields
+
+      serviceConfig("httpStatusThresholds") shouldBe JsArray(
+        JsObject("httpStatus" -> JsNumber(502), "count" -> JsNumber(2), "severity" -> JsString("warning"), "httpMethod" -> JsString("POST"), "alertingPlatform" -> JsString("Grafana")),
+        JsObject("httpStatus" -> JsNumber(504), "count" -> JsNumber(4), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"), "alertingPlatform" -> JsString("Sensu"))
       )
     }
 
@@ -118,7 +129,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS(404))).build.get.parseJson.asJsObject.fields
 
       serviceConfig("httpStatusThresholds") shouldBe JsArray(
-        JsObject("httpStatus" -> JsNumber(404), "count" -> JsNumber(1), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"))
+        JsObject("httpStatus" -> JsNumber(404), "count" -> JsNumber(1), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"), "alertingPlatform" -> JsString("Sensu"))
       )
     }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -333,15 +333,18 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service2Config = configs(1)
 
       val expected = JsArray(
-        JsObject("httpStatus" -> JsNumber(500),
+        JsObject("alertingPlatform" -> JsString("Sensu"),
+          "httpStatus" -> JsNumber(500),
           "count" -> JsNumber(19),
           "severity" -> JsString("warning"),
           "httpMethod" -> JsString("POST")),
-        JsObject("httpStatus" -> JsNumber(501),
+        JsObject("alertingPlatform" -> JsString("Sensu"),
+          "httpStatus" -> JsNumber(501),
           "count" -> JsNumber(20),
           "severity" -> JsString("critical"),
           "httpMethod" -> JsString("ALL_METHODS")),
-        JsObject("httpStatus" -> JsNumber(555),
+        JsObject("alertingPlatform" -> JsString("Sensu"),
+          "httpStatus" -> JsNumber(555),
           "count" -> JsNumber(55),
           "severity" -> JsString("critical"),
           "httpMethod" -> JsString("ALL_METHODS"))


### PR DESCRIPTION
What we have done
--

1. Updated Scala/SBT
2. TEL-4145 Permits HttpTrafficThreshold to target an alerting platform

References
--

1. https://jira.tools.tax.service.gov.uk/browse/TEL-4145

Evidence of work
--

1. Automated test

Risks
--

None known

Next steps
--

1. Update the alert-config repo to consume this change

Collaborators
--

1. Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
