### PR TITLE
TEL-4145 Filter out HTTP stats thresholds that do not target Sensu

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -160,7 +160,7 @@ case class AlertConfigBuilder(
              |"containerKillThreshold" : $containerKillThreshold,
              |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption.map(_.toJson.compactPrint).getOrElse(JsNull)},
              |"httpTrafficThresholds" : ${httpTrafficThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
-             |"httpStatusThresholds" : ${httpStatusThresholds.toJson.compactPrint},
+             |"httpStatusThresholds" : ${httpStatusThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
              |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.toJson.compactPrint},
              |"http5xxRateIncrease" : ${printSeq(http5xxRateIncrease)(Http5xxRateIncreaseProtocol.rateIncreaseFormat)},
              |"metricsThresholds" : ${printSeq(metricsThresholds)(MetricsThresholdProtocol.thresholdFormat)},

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -118,8 +118,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_502, 2, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_504, 4)).build.get.parseJson.asJsObject.fields
 
+      // note that only the Sensu targeting alert is actually written to JSON; the Grafana one is filtered out
       serviceConfig("httpStatusThresholds") shouldBe JsArray(
-        JsObject("httpStatus" -> JsNumber(502), "count" -> JsNumber(2), "severity" -> JsString("warning"), "httpMethod" -> JsString("POST"), "alertingPlatform" -> JsString("Grafana")),
         JsObject("httpStatus" -> JsNumber(504), "count" -> JsNumber(4), "severity" -> JsString("critical"), "httpMethod" -> JsString("ALL_METHODS"), "alertingPlatform" -> JsString("Sensu"))
       )
     }


### PR DESCRIPTION
What we have done
--

Following Muhammed's work here https://github.com/hmrc/alert-config-builder/pull/62/files and here https://github.com/hmrc/alert-config-builder/pull/63/files , we are filtering out the non-Sensu alerts from the JSON builder

Evidence of work
--

1. automated test

Risks
--

1. Continues to couple alert-config-builder to alert-config
2. continues to have the logic for building Grafana alerts within alert0-config and not here in alert-config-builder where I think perhaps it should be

Next steps
--

Complete the implemetation of this feature in alert-config

Collaborators
--

Co-authored by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
