### PR TITLE
TEL-4197 Add alerting platform flag to withHttp5xxPercentThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ We encourage contributors to make sure their work is well formatted using the fo
 
 [Visit the official Scalafmt documentation to view a complete list of tasks which can be run.](https://scalameta.org/scalafmt/docs/installation.html#task-keys)
 
-
 ### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -65,8 +65,10 @@ case class AlertConfigBuilder(
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
 
-  def withHttp5xxPercentThreshold(percentThreshold: Double, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity))
+  def withHttp5xxPercentThreshold(percentThreshold: Double,
+                                  severity: AlertSeverity = AlertSeverity.Critical,
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform = alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
@@ -237,8 +239,10 @@ case class TeamAlertConfigBuilder(
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
 
-  def withHttp5xxPercentThreshold(percentThreshold: Double, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity))
+  def withHttp5xxPercentThreshold(percentThreshold: Double,
+                                  severity: AlertSeverity = AlertSeverity.Critical,
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -147,6 +147,12 @@ case class AlertConfigBuilder(
           a.toJson.compactPrint
 
         ZoneToServiceDomainMapper.getServiceDomain(serviceDomain, platformService).map { serviceDomain =>
+          val updated5xxPercentThreshold = if (http5xxPercentThreshold.alertingPlatform != AlertingPlatform.Sensu) {
+            333.33
+          } else {
+            http5xxPercentThreshold.percentage
+          }
+
           s"""
              |{
              |"app": "$serviceName.$serviceDomain",
@@ -154,7 +160,10 @@ case class AlertConfigBuilder(
              |"errors-logged-threshold":$errorsLoggedThreshold,
              |"exception-threshold":${exceptionThreshold.toJson(ExceptionThresholdProtocol.thresholdFormat).compactPrint},
              |"5xx-threshold":${http5xxThreshold.toJson(Http5xxThresholdProtocol.thresholdFormat).compactPrint},
-             |"5xx-percent-threshold":${http5xxPercentThreshold.toJson(Http5xxPercentThresholdProtocol.thresholdFormat).compactPrint},
+             |"5xx-percent-threshold":${http5xxPercentThreshold
+              .copy(percentage = updated5xxPercentThreshold)
+              .toJson(Http5xxPercentThresholdProtocol.thresholdFormat)
+              .compactPrint},
              |"containerKillThreshold" : $containerKillThreshold,
              |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption
               .map(_.toJson.compactPrint)

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -67,8 +67,10 @@ case class AlertConfigBuilder(
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   severity: AlertSeverity = AlertSeverity.Critical,
-                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform = alertingPlatform))
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) = {
+    val adjustedPercentThreshold = if (alertingPlatform != AlertingPlatform.Sensu) 333.33 else percentThreshold
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(adjustedPercentThreshold, severity, alertingPlatform = alertingPlatform))
+  }
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
@@ -241,8 +243,10 @@ case class TeamAlertConfigBuilder(
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   severity: AlertSeverity = AlertSeverity.Critical,
-                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform))
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) = {
+    val adjustedPercentThreshold = if (alertingPlatform != AlertingPlatform.Sensu) 333.33 else percentThreshold
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(adjustedPercentThreshold, severity, alertingPlatform))
+  }
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -67,10 +67,8 @@ case class AlertConfigBuilder(
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   severity: AlertSeverity = AlertSeverity.Critical,
-                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) = {
-    val adjustedPercentThreshold = if (alertingPlatform != AlertingPlatform.Sensu) 333.33 else percentThreshold
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(adjustedPercentThreshold, severity, alertingPlatform = alertingPlatform))
-  }
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform = alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
@@ -243,10 +241,8 @@ case class TeamAlertConfigBuilder(
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   severity: AlertSeverity = AlertSeverity.Critical,
-                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) = {
-    val adjustedPercentThreshold = if (alertingPlatform != AlertingPlatform.Sensu) 333.33 else percentThreshold
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(adjustedPercentThreshold, severity, alertingPlatform))
-  }
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -20,7 +20,8 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 
 case class Http5xxPercentThreshold(
     percentage: Double = 100.0,
-    severity: AlertSeverity = AlertSeverity.Critical
+    severity: AlertSeverity = AlertSeverity.Critical,
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
 )
 
 object Http5xxPercentThresholdProtocol {
@@ -28,7 +29,7 @@ object Http5xxPercentThresholdProtocol {
 
   implicit val thresholdFormat: JsonFormat[Http5xxPercentThreshold] = {
     implicit val asf: JsonFormat[AlertSeverity] = alertSeverityFormat
-    jsonFormat2(Http5xxPercentThreshold)
+    jsonFormat3(Http5xxPercentThreshold)
   }
 
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -562,8 +562,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   }
 
   "build/configure http5xxPercentThreshold with required parameters for Grafana alerting platform" in {
-    val threshold            = 13.3
-    val overwrittenThreshold = 333.33
+    val threshold = 13.3
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
       .build
@@ -574,7 +573,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
-      "percentage"       -> JsNumber(overwrittenThreshold),
+      "percentage"       -> JsNumber(threshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
     )
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -562,7 +562,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   }
 
   "build/configure http5xxPercentThreshold with required parameters for Grafana alerting platform" in {
-    val threshold = 13.3
+    val threshold            = 13.3
+    val overwrittenThreshold = 333.33
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
       .build
@@ -573,7 +574,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
-      "percentage"       -> JsNumber(threshold),
+      "percentage"       -> JsNumber(overwrittenThreshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
     )
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -45,8 +45,9 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("exception-threshold") shouldBe JsObject("count" -> JsNumber(2), "severity" -> JsString("critical"))
       config("5xx-threshold") shouldBe JsObject("count" -> JsNumber(Int.MaxValue), "severity" -> JsString("critical"))
       config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"   -> JsString("critical"),
-        "percentage" -> JsNumber(100)
+        "severity"         -> JsString("critical"),
+        "percentage"       -> JsNumber(100),
+        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
       )
       config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
       config("containerKillThreshold") shouldBe JsNumber(56)
@@ -554,8 +555,26 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
-      "severity"   -> JsString("critical"),
-      "percentage" -> JsNumber(threshold)
+      "severity"         -> JsString("critical"),
+      "percentage"       -> JsNumber(threshold),
+      "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+    )
+  }
+
+  "build/configure http5xxPercentThreshold with required parameters for Grafana alerting platform" in {
+    val threshold = 13.3
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
+      .build
+      .get
+      .parseJson
+      .asJsObject
+      .fields
+
+    serviceConfig("5xx-percent-threshold") shouldBe JsObject(
+      "severity"         -> JsString("critical"),
+      "percentage"       -> JsNumber(threshold),
+      "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
     )
   }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -202,7 +202,8 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct Http5xxPercentThreshold for Grafana alerting platform" in {
-      val threshold = 19.9
+      val threshold            = 19.9
+      val overwrittenThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
         .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
@@ -216,12 +217,12 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "percentage"       -> JsNumber(threshold),
+        "percentage"       -> JsNumber(overwrittenThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "percentage"       -> JsNumber(threshold),
+        "percentage"       -> JsNumber(overwrittenThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
@@ -481,18 +482,20 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct withHttp5xxPercentThreshold for Grafana alerting platform" in {
+      val threshold            = 19.9
+      val overwrittenThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
-        .withHttp5xxPercentThreshold(12.2, AlertSeverity.Warning, AlertingPlatform.Grafana)
+        .withHttp5xxPercentThreshold(threshold, AlertSeverity.Warning, AlertingPlatform.Grafana)
 
       alertConfigBuilder.services shouldBe Seq("service1")
       val configs                              = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"       -> JsNumber(12.2),
+        "percentage"       -> JsNumber(overwrittenThreshold),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -190,12 +190,39 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service2Config = configs(1)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"   -> JsString("critical"),
-        "percentage" -> JsNumber(threshold)
+        "severity"         -> JsString("critical"),
+        "percentage"       -> JsNumber(threshold),
+        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"   -> JsString("critical"),
-        "percentage" -> JsNumber(threshold)
+        "severity"         -> JsString("critical"),
+        "percentage"       -> JsNumber(threshold),
+        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+      )
+    }
+
+    "return TeamAlertConfigBuilder with correct Http5xxPercentThreshold for Grafana alerting platform" in {
+      val threshold = 19.9
+      val alertConfigBuilder = TeamAlertConfigBuilder
+        .teamAlerts(Seq("service1", "service2"))
+        .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
+
+      alertConfigBuilder.services shouldBe Seq("service1", "service2")
+      val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
+
+      configs.size shouldBe 2
+      val service1Config = configs(0)
+      val service2Config = configs(1)
+
+      service1Config("5xx-percent-threshold") shouldBe JsObject(
+        "severity"         -> JsString("critical"),
+        "percentage"       -> JsNumber(threshold),
+        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
+      )
+      service2Config("5xx-percent-threshold") shouldBe JsObject(
+        "severity"         -> JsString("critical"),
+        "percentage"       -> JsNumber(threshold),
+        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
 
@@ -447,8 +474,27 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage" -> JsNumber(12.2),
-        "severity"   -> JsString("warning")
+        "percentage"       -> JsNumber(12.2),
+        "severity"         -> JsString("warning"),
+        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+      )
+    }
+
+    "return TeamAlertConfigBuilder with correct withHttp5xxPercentThreshold for Grafana alerting platform" in {
+      val alertConfigBuilder = TeamAlertConfigBuilder
+        .teamAlerts(Seq("service1"))
+        .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
+        .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
+        .withHttp5xxPercentThreshold(12.2, AlertSeverity.Warning, AlertingPlatform.Grafana)
+
+      alertConfigBuilder.services shouldBe Seq("service1")
+      val configs                              = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
+      val service1Config: Map[String, JsValue] = configs(0)
+
+      service1Config("5xx-percent-threshold") shouldBe JsObject(
+        "percentage"       -> JsNumber(12.2),
+        "severity"         -> JsString("warning"),
+        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -202,8 +202,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct Http5xxPercentThreshold for Grafana alerting platform" in {
-      val threshold            = 19.9
-      val overwrittenThreshold = 333.33
+      val threshold = 19.9
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
         .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
@@ -217,12 +216,12 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "percentage"       -> JsNumber(overwrittenThreshold),
+        "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "percentage"       -> JsNumber(overwrittenThreshold),
+        "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
@@ -482,20 +481,18 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct withHttp5xxPercentThreshold for Grafana alerting platform" in {
-      val threshold            = 12.2
-      val overwrittenThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
-        .withHttp5xxPercentThreshold(threshold, AlertSeverity.Warning, AlertingPlatform.Grafana)
+        .withHttp5xxPercentThreshold(12.2, AlertSeverity.Warning, AlertingPlatform.Grafana)
 
       alertConfigBuilder.services shouldBe Seq("service1")
       val configs                              = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"       -> JsNumber(overwrittenThreshold),
+        "percentage"       -> JsNumber(12.2),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -202,7 +202,8 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct Http5xxPercentThreshold for Grafana alerting platform" in {
-      val threshold = 19.9
+      val threshold            = 19.9
+      val overwrittenThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
         .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
@@ -216,12 +217,12 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "percentage"       -> JsNumber(threshold),
+        "percentage"       -> JsNumber(overwrittenThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "percentage"       -> JsNumber(threshold),
+        "percentage"       -> JsNumber(overwrittenThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
@@ -481,18 +482,20 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct withHttp5xxPercentThreshold for Grafana alerting platform" in {
+      val threshold            = 12.2
+      val overwrittenThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
-        .withHttp5xxPercentThreshold(12.2, AlertSeverity.Warning, AlertingPlatform.Grafana)
+        .withHttp5xxPercentThreshold(threshold, AlertSeverity.Warning, AlertingPlatform.Grafana)
 
       alertConfigBuilder.services shouldBe Seq("service1")
       val configs                              = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"       -> JsNumber(12.2),
+        "percentage"       -> JsNumber(overwrittenThreshold),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )


### PR DESCRIPTION
   - Add alerting platform flag to withHttp5xxPercentThreshold
   - Default it to Sensu and cover both Sensu and Grafana scenarios
   - Silencing Sensu when another platform is selected. 
   -- If using a non-Sensu Alerting platform, just raise the threshold to 333.33%. This way, we can silence Sensu without having to update the existing plugin, which is going to be deprecated soon