### PR TITLE
TEL-4154 Add alertingPlatform flag for withContainerKillThreshold

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -256,7 +256,6 @@ case class TeamAlertConfigBuilder(
     httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold] = Nil,
     httpAbsolutePercentSplitDownstreamServiceThresholds: Seq[HttpAbsolutePercentSplitDownstreamServiceThreshold] = Nil,
     httpAbsolutePercentSplitDownstreamHodThresholds: Seq[HttpAbsolutePercentSplitDownstreamHodThreshold] = Nil,
-    // containerKillThreshold: Int = 1,
     containerKillThreshold: ContainerKillThreshold = ContainerKillThreshold(1),
     httpTrafficThresholds: Seq[HttpTrafficThreshold] = Nil,
     httpStatusThresholds: Seq[HttpStatusThreshold] = Nil,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder
+
+case class ContainerKillThreshold(
+    count: Int = Int.MaxValue,
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -43,7 +43,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("app") shouldBe JsString("service1.domain.zone.1")
       config("handlers") shouldBe JsArray(JsString("h1"), JsString("h2"))
       config("exception-threshold") shouldBe JsObject("count" -> JsNumber(2), "severity" -> JsString("critical"))
-      config("5xx-threshold") shouldBe JsObject("count" -> JsNumber(Int.MaxValue), "severity" -> JsString("critical"), "alertingPlatform" -> JsString("Sensu"))
+      config("5xx-threshold") shouldBe JsObject(
+        "count"            -> JsNumber(Int.MaxValue),
+        "severity"         -> JsString("critical"),
+        "alertingPlatform" -> JsString("Sensu"))
       config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
         "percentage"       -> JsNumber(100),
@@ -229,7 +232,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .asJsObject
         .fields
 
-      serviceConfig("5xx-threshold") shouldBe JsObject("count" -> JsNumber(Int.MaxValue), "severity" -> JsString("warning"), "alertingPlatform" -> JsString("Grafana"))
+      serviceConfig("5xx-threshold") shouldBe JsObject(
+        "count"            -> JsNumber(Int.MaxValue),
+        "severity"         -> JsString("warning"),
+        "alertingPlatform" -> JsString("Grafana"))
     }
 
     "build/configure http 5xx threshold severity with given thresholds and unspecified severity" in {
@@ -241,7 +247,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .asJsObject
         .fields
 
-      serviceConfig("5xx-threshold") shouldBe JsObject("count" -> JsNumber(2), "severity" -> JsString("critical"), "alertingPlatform" -> JsString("Sensu"))
+      serviceConfig("5xx-threshold") shouldBe JsObject(
+        "count"            -> JsNumber(2),
+        "severity"         -> JsString("critical"),
+        "alertingPlatform" -> JsString("Sensu"))
     }
 
     "build/configure logMessageThresholds with given thresholds" in {
@@ -590,6 +599,32 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     serviceConfig("average-cpu-threshold") shouldBe JsNumber(threshold)
+  }
+
+  "use the configured value for withContainerKillThreshold when the alerting platform is Sensu" in {
+    val threshold = 3
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      .withContainerKillThreshold(threshold)
+      .build
+      .get
+      .parseJson
+      .asJsObject
+      .fields
+
+    serviceConfig("containerKillThreshold") shouldBe JsNumber(threshold)
+  }
+
+  "not use the configured value for withContainerKillThreshold when the alerting platform is Grafana" in {
+    val threshold = 3
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      .withContainerKillThreshold(threshold, AlertingPlatform.Grafana)
+      .build
+      .get
+      .parseJson
+      .asJsObject
+      .fields
+
+    serviceConfig("containerKillThreshold") shouldBe JsNumber(Int.MaxValue)
   }
 
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -39,7 +39,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       alertConfigBuilder.http5xxThreshold shouldBe Http5xxThreshold(Int.MaxValue, AlertSeverity.Critical)
       alertConfigBuilder.totalHttpRequestThreshold shouldBe Int.MaxValue
       alertConfigBuilder.exceptionThreshold shouldBe ExceptionThreshold(2, AlertSeverity.Critical)
-      alertConfigBuilder.containerKillThreshold shouldBe 1
+      alertConfigBuilder.containerKillThreshold shouldBe ContainerKillThreshold(1, AlertingPlatform.Sensu)
       alertConfigBuilder.averageCPUThreshold shouldBe Int.MaxValue
       alertConfigBuilder.httpStatusThresholds shouldBe List()
       alertConfigBuilder.http90PercentileResponseTimeThresholds shouldBe List()


### PR DESCRIPTION
* Adds the ability to set the `alertingPlatform` to the `withContainerKillThreshold` alert
* Makes sure the JSON created by the builder is still a single number as the Sensu plugin expects
* If the alerting platform isn't Sensu then it sets the threshold to `Int.MaxValue` so it doesn't trigger in Sensu

Co-authored-by: Rob White <Crumplepang@users.noreply.github.com>