### PR TITLE
Tel 4156

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.17.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.18.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"  % "1.6.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -114,8 +114,12 @@ case class AlertConfigBuilder(
   def withContainerKillThreshold(containerCrashThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerCrashThreshold, alertingPlatform))
 
-  def withLogMessageThreshold(message: String, threshold: Int, lessThanMode: Boolean = false, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity))
+  def withLogMessageThreshold(message: String,
+                              threshold: Int,
+                              lessThanMode: Boolean = false,
+                              severity: AlertSeverity = AlertSeverity.Critical,
+                              alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+    this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
   def withAverageCPUThreshold(averageCPUThreshold: Int) =
     this.copy(averageCPUThreshold = averageCPUThreshold)
@@ -336,8 +340,12 @@ case class TeamAlertConfigBuilder(
   def withTotalHttpRequestsCountThreshold(threshold: Int) =
     this.copy(totalHttpRequestThreshold = threshold)
 
-  def withLogMessageThreshold(message: String, threshold: Int, lessThanMode: Boolean = false, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity))
+  def withLogMessageThreshold(message: String,
+                              threshold: Int,
+                              lessThanMode: Boolean = false,
+                              severity: AlertSeverity = AlertSeverity.Critical,
+                              alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+    this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
   def withAverageCPUThreshold(averageCPUThreshold: Int) =
     this.copy(averageCPUThreshold = averageCPUThreshold)

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -129,6 +129,7 @@ case class AlertConfigBuilder(
 
   def build: Option[String] = {
     import Http90PercentileResponseTimeThresholdProtocol._
+    import LogMessageThresholdProtocol._
     import HttpTrafficThresholdProtocol._
     import HttpStatusThresholdProtocol._
     import HttpStatusPercentThresholdProtocol._
@@ -210,7 +211,7 @@ case class AlertConfigBuilder(
              |"http5xxRateIncrease" : ${printSeq(http5xxRateIncrease)(Http5xxRateIncreaseProtocol.rateIncreaseFormat)},
              |"metricsThresholds" : ${printSeq(metricsThresholds)(MetricsThresholdProtocol.thresholdFormat)},
              |"total-http-request-threshold": $totalHttpRequestThreshold,
-             |"log-message-thresholds" : $buildLogMessageThresholdsJson,
+             |"log-message-thresholds" : ${logMessageThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
              |"average-cpu-threshold" : $averageCPUThreshold,
              |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds)(
               HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
@@ -222,11 +223,6 @@ case class AlertConfigBuilder(
               """.stripMargin
         }
     }
-  }
-
-  def buildLogMessageThresholdsJson = {
-    import LogMessageThresholdProtocol._
-    logMessageThresholds.toJson.compactPrint
   }
 
   def getZone(appConfigFile: File, platformService: Boolean = false): Option[String] =

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
@@ -27,7 +27,12 @@ case class LogMessageThreshold(
     alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
 )
 
-object LogMessageThresholdProtocol extends DefaultJsonProtocol {
-  implicit val asf: JsonFormat[AlertSeverity]          = alertSeverityFormat
-  implicit val format: JsonFormat[LogMessageThreshold] = jsonFormat5(LogMessageThreshold)
+object LogMessageThresholdProtocol extends {
+  import DefaultJsonProtocol._
+
+  implicit val logMessageThresholdFormat: JsonFormat[LogMessageThreshold] = {
+    implicit val asf: JsonFormat[AlertSeverity] = alertSeverityFormat
+    jsonFormat5(LogMessageThreshold)
+  }
+
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
@@ -23,10 +23,11 @@ case class LogMessageThreshold(
     message: String,
     count: Int,
     lessThanMode: Boolean = false,
-    severity: AlertSeverity = AlertSeverity.Critical
+    severity: AlertSeverity = AlertSeverity.Critical,
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
 )
 
 object LogMessageThresholdProtocol extends DefaultJsonProtocol {
   implicit val asf: JsonFormat[AlertSeverity]          = alertSeverityFormat
-  implicit val format: JsonFormat[LogMessageThreshold] = jsonFormat4(LogMessageThreshold)
+  implicit val format: JsonFormat[LogMessageThreshold] = jsonFormat5(LogMessageThreshold)
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -300,13 +300,6 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "lessThanMode"     -> JsTrue,
           "severity"         -> JsString("warning"),
           "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
-        ),
-        JsObject(
-          "message"          -> JsString("SIMULATED_ERROR5"),
-          "count"            -> JsNumber(7),
-          "lessThanMode"     -> JsFalse,
-          "severity"         -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
         )
       )
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -43,13 +43,13 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("app") shouldBe JsString("service1.domain.zone.1")
       config("handlers") shouldBe JsArray(JsString("h1"), JsString("h2"))
       config("exception-threshold") shouldBe JsObject(
-        "count" -> JsNumber(2),
-        "severity" -> JsString("critical"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString),
+        "count"            -> JsNumber(2),
+        "severity"         -> JsString("critical"),
+        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
       )
       config("5xx-threshold") shouldBe JsObject(
-        "count" -> JsNumber(Int.MaxValue),
-        "severity" -> JsString("critical"),
+        "count"            -> JsNumber(Int.MaxValue),
+        "severity"         -> JsString("critical"),
         "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
       )
       config("5xx-percent-threshold") shouldBe JsObject(
@@ -136,7 +136,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "count"            -> JsNumber(2),
           "severity"         -> JsString("warning"),
           "httpMethod"       -> JsString("POST"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        ),
         JsObject(
           "httpStatus"       -> JsNumber(504),
           "count"            -> JsNumber(4),
@@ -237,7 +238,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .asJsObject
         .fields
 
-      serviceConfig("5xx-threshold") shouldBe JsObject("count" -> JsNumber(Int.MaxValue), "severity" -> JsString("warning"), "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString))
+      serviceConfig("5xx-threshold") shouldBe JsObject(
+        "count"            -> JsNumber(Int.MaxValue),
+        "severity"         -> JsString("warning"),
+        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString))
     }
 
     "build/configure http 5xx threshold severity with given thresholds and unspecified severity" in {
@@ -249,7 +253,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .asJsObject
         .fields
 
-      serviceConfig("5xx-threshold") shouldBe JsObject("count" -> JsNumber(2), "severity" -> JsString("critical"), "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString))
+      serviceConfig("5xx-threshold") shouldBe JsObject(
+        "count"            -> JsNumber(2),
+        "severity"         -> JsString("critical"),
+        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString))
     }
 
     "build/configure logMessageThresholds with given thresholds" in {
@@ -258,6 +265,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .withLogMessageThreshold("SIMULATED_ERROR2", 4, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR3", 5, lessThanMode = true)
         .withLogMessageThreshold("SIMULATED_ERROR4", 6, lessThanMode = true, AlertSeverity.Warning)
+        .withLogMessageThreshold("SIMULATED_ERROR5", 7, alertingPlatform = AlertingPlatform.Grafana)
         .build
         .get
         .parseJson
@@ -265,10 +273,41 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .fields
 
       serviceConfig("log-message-thresholds") shouldBe JsArray(
-        JsObject("message" -> JsString("SIMULATED_ERROR1"), "count" -> JsNumber(3), "lessThanMode" -> JsFalse, "severity" -> JsString("critical")),
-        JsObject("message" -> JsString("SIMULATED_ERROR2"), "count" -> JsNumber(4), "lessThanMode" -> JsFalse, "severity" -> JsString("critical")),
-        JsObject("message" -> JsString("SIMULATED_ERROR3"), "count" -> JsNumber(5), "lessThanMode" -> JsTrue, "severity"  -> JsString("critical")),
-        JsObject("message" -> JsString("SIMULATED_ERROR4"), "count" -> JsNumber(6), "lessThanMode" -> JsTrue, "severity"  -> JsString("warning"))
+        JsObject(
+          "message"          -> JsString("SIMULATED_ERROR1"),
+          "count"            -> JsNumber(3),
+          "lessThanMode"     -> JsFalse,
+          "severity"         -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        ),
+        JsObject(
+          "message"          -> JsString("SIMULATED_ERROR2"),
+          "count"            -> JsNumber(4),
+          "lessThanMode"     -> JsFalse,
+          "severity"         -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        ),
+        JsObject(
+          "message"          -> JsString("SIMULATED_ERROR3"),
+          "count"            -> JsNumber(5),
+          "lessThanMode"     -> JsTrue,
+          "severity"         -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        ),
+        JsObject(
+          "message"          -> JsString("SIMULATED_ERROR4"),
+          "count"            -> JsNumber(6),
+          "lessThanMode"     -> JsTrue,
+          "severity"         -> JsString("warning"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        ),
+        JsObject(
+          "message"          -> JsString("SIMULATED_ERROR5"),
+          "count"            -> JsNumber(7),
+          "lessThanMode"     -> JsFalse,
+          "severity"         -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
+        )
       )
     }
 
@@ -514,8 +553,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     val expected = JsObject(
-      "severity" -> JsString("critical"),
-      "count"    -> JsNumber(threshold),
+      "severity"         -> JsString("critical"),
+      "count"            -> JsNumber(threshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
     )
 
@@ -533,8 +572,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     val expected = JsObject(
-      "severity" -> JsString("critical"),
-      "count"    -> JsNumber(Int.MaxValue),
+      "severity"         -> JsString("critical"),
+      "count"            -> JsNumber(Int.MaxValue),
       "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
     )
 
@@ -552,8 +591,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     val expected = JsObject(
-      "severity" -> JsString("warning"),
-      "count"    -> JsNumber(threshold),
+      "severity"         -> JsString("warning"),
+      "count"            -> JsNumber(threshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
     )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -241,13 +241,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service2Config = configs(1)
 
       service1Config("exception-threshold") shouldBe JsObject(
-        "count"    -> JsNumber(threshold),
-        "severity" -> JsString("warning"),
+        "count"            -> JsNumber(threshold),
+        "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
       )
       service2Config("exception-threshold") shouldBe JsObject(
-        "count"    -> JsNumber(threshold),
-        "severity" -> JsString("warning"),
+        "count"            -> JsNumber(threshold),
+        "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
       )
     }
@@ -266,13 +266,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service2Config = configs(1)
 
       service1Config("exception-threshold") shouldBe JsObject(
-        "count"    -> JsNumber(Int.MaxValue),
-        "severity" -> JsString("warning"),
+        "count"            -> JsNumber(Int.MaxValue),
+        "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("exception-threshold") shouldBe JsObject(
-        "count"    -> JsNumber(Int.MaxValue),
-        "severity" -> JsString("warning"),
+        "count"            -> JsNumber(Int.MaxValue),
+        "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
@@ -553,6 +553,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
         .withLogMessageThreshold("SIMULATED_ERROR3", 21, lessThanMode = true, AlertSeverity.Warning)
+        .withLogMessageThreshold("SIMULATED_ERROR4", 22, alertingPlatform = AlertingPlatform.Grafana)
 
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
       val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
@@ -563,22 +564,32 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       val expected = JsArray(
         JsObject(
-          "message"      -> JsString("SIMULATED_ERROR1"),
-          "count"        -> JsNumber(19),
-          "lessThanMode" -> JsFalse,
-          "severity"     -> JsString("critical")
+          "message"          -> JsString("SIMULATED_ERROR1"),
+          "count"            -> JsNumber(19),
+          "lessThanMode"     -> JsFalse,
+          "severity"         -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
         ),
         JsObject(
-          "message"      -> JsString("SIMULATED_ERROR2"),
-          "count"        -> JsNumber(20),
-          "lessThanMode" -> JsTrue,
-          "severity"     -> JsString("critical")
+          "message"          -> JsString("SIMULATED_ERROR2"),
+          "count"            -> JsNumber(20),
+          "lessThanMode"     -> JsTrue,
+          "severity"         -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
         ),
         JsObject(
-          "message"      -> JsString("SIMULATED_ERROR3"),
-          "count"        -> JsNumber(21),
-          "lessThanMode" -> JsTrue,
-          "severity"     -> JsString("warning")
+          "message"          -> JsString("SIMULATED_ERROR3"),
+          "count"            -> JsNumber(21),
+          "lessThanMode"     -> JsTrue,
+          "severity"         -> JsString("warning"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        ),
+        JsObject(
+          "message"          -> JsString("SIMULATED_ERROR4"),
+          "count"            -> JsNumber(22),
+          "lessThanMode"     -> JsFalse,
+          "severity"         -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
         )
       )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -583,13 +583,6 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "lessThanMode"     -> JsTrue,
           "severity"         -> JsString("warning"),
           "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
-        ),
-        JsObject(
-          "message"          -> JsString("SIMULATED_ERROR4"),
-          "count"            -> JsNumber(22),
-          "lessThanMode"     -> JsFalse,
-          "severity"         -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
         )
       )
 


### PR DESCRIPTION
Tested a locally published package in alert-config and the output's difference is what was expected:
![image](https://github.com/hmrc/alert-config-builder/assets/1422984/13091529-4b4b-47c6-a5d1-9edd83f3d7c2)