### PR TITLE
TEL-4265 Moves YAML builder from alert-config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+What did we do?
+--
+
+1.
+
+References
+--
+
+https://jira.tools.tax.service.gov.uk/browse/TEL-
+
+Evidence of work
+--
+
+1.
+
+Next Steps
+--
+
+1.
+
+Risks
+--
+
+1.
+
+Collaboration
+--
+
+Co-authored-by:

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -5,7 +5,9 @@ object LibDependencies {
   val compile = Seq(
     "org.reflections" %  "reflections"   % "0.10.2",
     "io.spray"        %% "spray-json"    % "1.3.6",
-    "org.yaml"        %  "snakeyaml"     % "1.33"
+    "org.yaml"        %  "snakeyaml"     % "1.33",
+    "com.fasterxml.jackson.dataformat" %  "jackson-dataformat-yaml" % "2.15.3",
+    "com.fasterxml.jackson.module"     %% "jackson-module-scala"    % "2.15.3"
   )
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.18.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.20.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"  % "1.6.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.yaml
+
+case class TopLevelConfig(services: Seq[ServiceConfig])
+
+case class ServiceConfig(service: String, alerts: Alerts, pagerduty: Seq[PagerDuty])
+
+case class Alerts(
+                   averageCPUThreshold: Option[YAMLAverageCPUThresholdAlert] = None,
+                   containerKillThreshold: Option[YAMLContainerKillThresholdAlert] = None,
+                   errorsLoggedThreshold: Option[YAMLErrorsLoggedThresholdAlert] = None,
+                   exceptionThreshold: Option[YAMLExceptionThresholdAlert] = None,
+                   logMessageThresholds: Option[Seq[YAMLLogMessageThresholdAlert]] = None,
+                   http5xxThreshold: Option[YAMLHttp5xxThresholdAlert] = None,
+                   http5xxPercentThreshold: Option[YAMLHttp5xxPercentThresholdAlert] = None,
+                   httpStatusPercentThresholds: Option[Seq[YAMLHttpStatusPercentThresholdAlert]] = None,
+                   httpStatusThresholds: Option[Seq[YAMLHttpStatusThresholdAlert]] = None,
+                   httpTrafficThresholds: Option[Seq[YAMLHttpTrafficThresholdAlert]] = None,
+                   totalHttpRequestThreshold: Option[YAMLTotalHttpRequestThresholdAlert] = None,
+                   metricsThresholds: Option[Seq[YAMLMetricsThresholdAlert]] = None
+                 )
+
+case class PagerDuty(
+                      // name: String,
+                      integrationKeyName: String
+                      // slackChannel: String
+                    )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YAMLAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YAMLAlerts.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.yaml
+
+case class YAMLAverageCPUThresholdAlert(
+                                         count: Int
+                                       )
+
+case class YAMLContainerKillThresholdAlert(
+                                            count: Int
+                                          )
+
+case class YAMLErrorsLoggedThresholdAlert(
+                                           count: Int
+                                         )
+
+case class YAMLExceptionThresholdAlert(
+                                        count: Int,
+                                        severity: String
+                                      )
+
+case class YAMLHttp5xxPercentThresholdAlert(
+                                             percentage: Double,
+                                             severity: String
+                                           )
+
+case class YAMLHttp5xxThresholdAlert(
+                                      count: Int,
+                                      severity: String
+                                    )
+
+case class YAMLHttpStatusThresholdAlert(
+                                         count: Int = 1,
+                                         httpMethod: String,
+                                         httpStatus: Int,
+                                         severity: String
+                                       )
+
+case class YAMLHttpStatusPercentThresholdAlert(
+                                                percentage: Double,
+                                                httpMethod: String,
+                                                httpStatus: Int,
+                                                severity: String
+                                              )
+
+case class YAMLLogMessageThresholdAlert(
+                                         count: Int,
+                                         lessThanMode: Boolean,
+                                         message: String,
+                                         severity: String
+                                       )
+
+case class YAMLHttpTrafficThresholdAlert(
+                                          count: Int,
+                                          maxMinutesBelowThreshold: Int,
+                                          severity: String
+                                        )
+
+case class YAMLMetricsThresholdAlert(
+                                      count: Double,
+                                      name: String,
+                                      query: String,
+                                      severity: String,
+                                      invert: Boolean
+                                    )
+
+case class YAMLTotalHttpRequestThresholdAlert(
+                                               count: Int
+                                             )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.yaml
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import uk.gov.hmrc.alertconfig.builder.AlertingPlatform.Grafana
+import uk.gov.hmrc.alertconfig.builder.{AlertConfig, AlertConfigBuilder, AlertingPlatform, AverageCPUThreshold, ContainerKillThreshold, Environment, ErrorsLoggedThreshold, ExceptionThreshold, Http5xxPercentThreshold, Http5xxThreshold, HttpStatusPercentThreshold, HttpStatusThreshold, HttpTrafficThreshold, LogMessageThreshold, Logger, MetricsThreshold, TotalHttpRequestThreshold}
+
+import java.io.File
+
+object YAMLBuilder {
+
+  val logger = new Logger()
+
+  def run(alertConfigs: Seq[AlertConfig], environment: String): Unit = {
+
+    val currentEnvironment = Environment.get(environment)
+    val topLevelConfig     = TopLevelConfig(convert(alertConfigs, currentEnvironment))
+    logger.debug(s"Generating YAML for $currentEnvironment")
+
+    val mapper = new ObjectMapper(
+      new YAMLFactory()
+        .disable(Feature.WRITE_DOC_START_MARKER)
+        .enable(Feature.INDENT_ARRAYS_WITH_INDICATOR)
+    )
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+    mapper.registerModule(DefaultScalaModule)
+
+    mapper.writeValue(new File(s"./target/output/services.yml"), topLevelConfig)
+    logger.debug(s"Done generating YAML for $currentEnvironment")
+  }
+
+  def convert(alertConfigs: Seq[AlertConfig], currentEnvironment: Environment): Seq[ServiceConfig] = {
+    alertConfigs.flatMap(convert(_, currentEnvironment))
+  }
+
+  def convert(alertConfig: AlertConfig, currentEnvironment: Environment): Seq[ServiceConfig] = {
+    val filtered             = alertConfig.environmentConfig.filter(_.enabledEnvironments.contains(currentEnvironment))
+    val enabledHandlersInEnv = filtered.map(_.handlerName).toSet
+    alertConfig.alertConfig.flatMap(convert(_, enabledHandlersInEnv))
+  }
+
+  def convert(alertConfigBuilder: AlertConfigBuilder, environmentDefinedHandlers: Set[String]): Option[ServiceConfig] = {
+    val enabledHandlers = alertConfigBuilder.handlers.toSet.intersect(environmentDefinedHandlers)
+    if (enabledHandlers.isEmpty) {
+      None
+    } else {
+      Some(
+        ServiceConfig(
+          service = alertConfigBuilder.serviceName.trim.toLowerCase.replaceAll(" ", "-"),
+          alerts = convertAlerts(alertConfigBuilder),
+          pagerduty = enabledHandlers.map(handler => PagerDuty(integrationKeyName = handler)).toSeq
+        ))
+    }
+  }
+
+  def convertAlerts(alertConfigBuilder: AlertConfigBuilder): Alerts = {
+    Alerts(
+      averageCPUThreshold = convertAverageCPUThreshold(alertConfigBuilder.averageCPUThreshold),
+      containerKillThreshold = convertContainerKillThreshold(alertConfigBuilder.containerKillThreshold),
+      errorsLoggedThreshold = convertErrorsLoggedThreshold(alertConfigBuilder.errorsLoggedThreshold),
+      exceptionThreshold = convertExceptionThreshold(alertConfigBuilder.exceptionThreshold),
+      http5xxPercentThreshold = convertHttp5xxPercentThresholds(alertConfigBuilder.http5xxPercentThreshold),
+      http5xxThreshold = convertHttp5xxThreshold(alertConfigBuilder.http5xxThreshold),
+      httpStatusPercentThresholds = convertHttpStatusPercentThresholdAlerts(alertConfigBuilder.httpStatusPercentThresholds),
+      httpStatusThresholds = convertHttpStatusThresholds(alertConfigBuilder.httpStatusThresholds),
+      httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds),
+      logMessageThresholds = convertLogMessageThresholdAlerts(alertConfigBuilder.logMessageThresholds),
+      totalHttpRequestThreshold = convertTotalHttpRequestThreshold(alertConfigBuilder.totalHttpRequestThreshold),
+      metricsThresholds = convertMetricsThreshold(alertConfigBuilder.metricsThresholds)
+    )
+  }
+
+  def convertAverageCPUThreshold(averageCPUThreshold: AverageCPUThreshold): Option[YAMLAverageCPUThresholdAlert] = {
+    Option.when(averageCPUThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+      YAMLAverageCPUThresholdAlert(averageCPUThreshold.count)
+    )
+  }
+
+  def convertContainerKillThreshold(containerKillThreshold: ContainerKillThreshold): Option[YAMLContainerKillThresholdAlert] = {
+    Option.when(containerKillThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+      YAMLContainerKillThresholdAlert(containerKillThreshold.count)
+    )
+  }
+
+  def convertErrorsLoggedThreshold(errorsLoggedThreshold: ErrorsLoggedThreshold): Option[YAMLErrorsLoggedThresholdAlert] = {
+    Option.when(errorsLoggedThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+      YAMLErrorsLoggedThresholdAlert(errorsLoggedThreshold.count)
+    )
+  }
+
+  def convertExceptionThreshold(exceptionThreshold: ExceptionThreshold): Option[YAMLExceptionThresholdAlert] = {
+    Option.when(exceptionThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+      YAMLExceptionThresholdAlert(
+        count = exceptionThreshold.count,
+        severity = exceptionThreshold.severity.toString
+      )
+    )
+  }
+
+  def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Http5xxPercentThreshold): Option[YAMLHttp5xxPercentThresholdAlert] = {
+    Option.when(http5xxPercentThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+      YAMLHttp5xxPercentThresholdAlert(
+        percentage = http5xxPercentThreshold.percentage,
+        severity = http5xxPercentThreshold.severity.toString
+      )
+    )
+  }
+
+  def convertHttp5xxThreshold(http5xxThreshold: Http5xxThreshold): Option[YAMLHttp5xxThresholdAlert] = {
+    Option.when(http5xxThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+      YAMLHttp5xxThresholdAlert(
+        count = http5xxThreshold.count,
+        severity = http5xxThreshold.severity.toString
+      )
+    )
+  }
+
+  def convertHttpStatusThresholds(httpStatusThresholds: Seq[HttpStatusThreshold]): Option[Seq[YAMLHttpStatusThresholdAlert]] = {
+    val converted = httpStatusThresholds.withFilter(_.alertingPlatform == Grafana).map { threshold =>
+      YAMLHttpStatusThresholdAlert(
+        count = threshold.count,
+        httpMethod = threshold.httpMethod.toString,
+        httpStatus = threshold.httpStatus.status,
+        severity = threshold.severity.toString
+      )
+    }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
+  def convertLogMessageThresholdAlerts(logMessageThresholds: Seq[LogMessageThreshold]): Option[Seq[YAMLLogMessageThresholdAlert]] = {
+    val converted = logMessageThresholds.withFilter(_.alertingPlatform == Grafana).map { threshold =>
+      YAMLLogMessageThresholdAlert(
+        message = threshold.message,
+        count = threshold.count,
+        lessThanMode = threshold.lessThanMode,
+        severity = threshold.severity.toString
+      )
+    }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
+  def convertHttpStatusPercentThresholdAlerts(
+                                               httpStatusPercentThresholds: Seq[HttpStatusPercentThreshold]): Option[Seq[YAMLHttpStatusPercentThresholdAlert]] = {
+    val converted = httpStatusPercentThresholds.withFilter(_.alertingPlatform == Grafana).map { threshold =>
+      YAMLHttpStatusPercentThresholdAlert(
+        percentage = threshold.percentage,
+        httpMethod = threshold.httpMethod.toString,
+        httpStatus = threshold.httpStatus.status,
+        severity = threshold.severity.toString
+      )
+    }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
+  def convertHttpTrafficThresholds(httpTrafficThresholds: Seq[HttpTrafficThreshold]): Option[Seq[YAMLHttpTrafficThresholdAlert]] = {
+    val converted = httpTrafficThresholds.flatMap { threshold =>
+      if (threshold.alertingPlatform == Grafana) {
+        Seq(
+          threshold.warning.map { warningCount =>
+            YAMLHttpTrafficThresholdAlert(
+              count = warningCount,
+              maxMinutesBelowThreshold = threshold.maxMinutesBelowThreshold,
+              severity = "warning"
+            )
+          },
+          threshold.critical.map { criticalCount =>
+            YAMLHttpTrafficThresholdAlert(
+              count = criticalCount,
+              maxMinutesBelowThreshold = threshold.maxMinutesBelowThreshold,
+              severity = "critical"
+            )
+          }
+        ).flatten
+      } else {
+        Seq.empty
+      }
+    }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
+  def convertTotalHttpRequestThreshold(totalHttpRequestThreshold: TotalHttpRequestThreshold): Option[YAMLTotalHttpRequestThresholdAlert] = {
+    Option.when(totalHttpRequestThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+      YAMLTotalHttpRequestThresholdAlert(totalHttpRequestThreshold.count)
+    )
+  }
+
+  def convertMetricsThreshold(metricsThreshold: Seq[MetricsThreshold]): Option[Seq[YAMLMetricsThresholdAlert]] = {
+    val converted = metricsThreshold.flatMap { threshold =>
+      if (threshold.alertingPlatform == Grafana) {
+        Seq(
+          threshold.warning.map { warningCount =>
+            YAMLMetricsThresholdAlert(
+              count = warningCount,
+              name = threshold.name,
+              query = threshold.query,
+              severity = "warning",
+              invert = threshold.invert
+            )
+          },
+          threshold.critical.map { criticalCount =>
+            YAMLMetricsThresholdAlert(
+              count = criticalCount,
+              name = threshold.name,
+              query = threshold.query,
+              severity = "critical",
+              invert = threshold.invert
+            )
+          }
+        ).flatten
+      } else {
+        Seq.empty
+      }
+    }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilderSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder
+
+import uk.gov.hmrc.alertconfig.builder.yaml.{YAMLBuilder, YAMLContainerKillThresholdAlert}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import spray.json.{JsArray, JsObject, JsString}
+import spray.json._
+
+class YAMLBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    System.setProperty("app-config-path", "src/test/resources/app-config")
+    System.setProperty("zone-mapping-path", "src/test/resources/zone-to-service-domain-mapping.yml")
+  }
+
+  "convert(Seq[AlertConfig])" should {
+    "when supplied an empty sequence it should return an empty list" in {
+      YAMLBuilder.convert(Seq(), Environment.Qa) shouldBe List()
+    }
+  }
+
+  "convertAlerts(alertConfigBuilder)" should {
+    "return Alerts" in {
+
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withContainerKillThreshold(56, AlertingPlatform.Grafana)
+
+      val output = YAMLBuilder.convertAlerts(config)
+
+      output.containerKillThreshold shouldBe Some(YAMLContainerKillThresholdAlert(56))
+    }
+  }
+}


### PR DESCRIPTION
What we have done
--

1. Added Scala for YAML builder
2. Added Github template
3. Adds bare-bones unit test for YAMLBuilder
4. Updated auto builder package

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4265

Evidence of work
--

compiles

Next Steps
--

1. Consume this YAML class from alert-config

Risks
--

1. Unit test doesn't do a lot... better than nothing though
2. I'm hoping that it writes to the correct `target` directory when consumed as a library from `alert-config` - will have to see. Haven't tested with that yet, - **is there a way to test a different `alert-config-builder` lib version with `alert-config`?**

Collaboration
--

Co-authored by: Ali Bahman <abn@webit4.me>

