### PR TITLE
TEL-4323 ensure default platform is set in both AlertConfigBuilder and TeamAlertConfigBuilder

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -368,7 +368,7 @@ case class TeamAlertConfigBuilder(
                               alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
-  def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+  def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(averageCPUThreshold = AverageCPUThreshold(averageCPUThreshold, alertingPlatform = alertingPlatform))
 
   def isPlatformService(platformService: Boolean): TeamAlertConfigBuilder =

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
@@ -91,7 +91,7 @@ object YamlBuilder {
   }
 
   def convertAverageCPUThreshold(averageCPUThreshold: AverageCPUThreshold, currentEnvironment: Environment): Option[YamlAverageCPUThresholdAlert] = {
-    Option.when(isGrafanaEnabled(averageCPUThreshold.alertingPlatform, currentEnvironment, AlertType.AverageCPUThreshold))(
+    Option.when(isGrafanaEnabled(averageCPUThreshold.alertingPlatform, currentEnvironment, AlertType.AverageCPUThreshold) && averageCPUThreshold.count < Int.MaxValue)(
       YamlAverageCPUThresholdAlert(averageCPUThreshold.count)
     )
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -24,20 +24,6 @@ import spray.json._
 
 class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
-  def setEnv(key: String, value: String) = {
-    val field = System.getenv().getClass.getDeclaredField("m")
-    field.setAccessible(true)
-    val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
-    map.put(key, value)
-  }
-
-  def unSetEnv(key: String) = {
-    val field = System.getenv().getClass.getDeclaredField("m")
-    field.setAccessible(true)
-    val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
-    map.remove(key)
-  }
-
   override def beforeEach(): Unit = {
     System.setProperty("app-config-path", "src/test/resources/app-config")
     System.setProperty("zone-mapping-path", "src/test/resources/zone-to-service-domain-mapping.yml")
@@ -738,7 +724,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   }
 
   "disable averageCPUThreshold when the environment is integration" in {
-    setEnv("ENVIRONMENT", "integration")
+    EnvironmentVars.setEnv("ENVIRONMENT", "integration")
 
     val threshold = 15
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
@@ -751,11 +737,11 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("average-cpu-threshold") shouldBe JsNumber(Int.MaxValue)
 
-    unSetEnv("ENVIRONMENT")
+    EnvironmentVars.unsetEnv("ENVIRONMENT")
   }
 
   "enable averageCPUThreshold when the environment is integration but alertingPlatform is Sensu" in {
-    setEnv("ENVIRONMENT", "integration")
+    EnvironmentVars.setEnv("ENVIRONMENT", "integration")
 
     val threshold = 15
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
@@ -768,7 +754,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("average-cpu-threshold") shouldBe JsNumber(threshold)
 
-    unSetEnv("ENVIRONMENT")
+    EnvironmentVars.unsetEnv("ENVIRONMENT")
   }
 
   "use the configured value for containerKillThreshold when the alerting platform is Sensu" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentVars.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentVars.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder
+
+object EnvironmentVars {
+  def setEnv(key: String, value: String) = {
+    val field = System.getenv().getClass.getDeclaredField("m")
+    field.setAccessible(true)
+    val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
+    map.put(key, value)
+  }
+
+  def unsetEnv(key: String) = {
+    val field = System.getenv().getClass.getDeclaredField("m")
+    field.setAccessible(true)
+    val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
+    map.remove(key)
+  }
+}


### PR DESCRIPTION
What did we do?
--

1. Set alertingPlatform to Default for withAverageCPUThreshold for TeamAlertConfigBuilder (previous PR only set it in AlertConfigBuilder)
2. Added tests which would have caught the above mistake
3. Added tests for YAML config
4. Do not add AverageCPUThreshold to YAML if the threshold is set to Int.MaxValue (e.g. disabled)
5. rename unSetEnv to unsetEnv

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4323

Evidence of work
--

1. Passing tests

Next Steps
--

1. Update alert-config and migrate averageCPUThreshold alert in integration from sensu to grafana
