### PR TITLE
TEL-4323 migrate all alerts in integration to grafana

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -233,7 +233,7 @@ case class AlertConfigBuilder(
              |"httpStatusThresholds" : ${httpStatusThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).toJson.compactPrint},
              |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).toJson.compactPrint},
              |"http5xxRateIncrease" : ${printSeq(http5xxRateIncrease)(Http5xxRateIncreaseProtocol.rateIncreaseFormat)},
-             |"metricsThresholds" : ${printSeq(metricsThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu))(
+             |"metricsThresholds" : ${printSeq(metricsThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)))(
               MetricsThresholdProtocol.thresholdFormat)},
              |"total-http-request-threshold": $updatedTotalHttpRequestThreshold,
              |"log-message-thresholds" : ${logMessageThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).toJson.compactPrint},

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -67,7 +67,7 @@ case class AlertConfigBuilder(
 
   def withHttp5xxThreshold(http5xxThreshold: Int,
                            severity: AlertSeverity = AlertSeverity.Critical,
-                           alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                           alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,
@@ -168,7 +168,7 @@ case class AlertConfigBuilder(
             http5xxPercentThreshold.percentage
           }
 
-          val updated5xxThreshold = if (http5xxThreshold.alertingPlatform != AlertingPlatform.Sensu) {
+          val updated5xxThreshold = if (isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold)) {
             // if this alert is configured to use NOT Sensu, then set it to an unreasonably high threshold so
             // it will never be triggered
             Int.MaxValue
@@ -306,7 +306,7 @@ case class TeamAlertConfigBuilder(
 
   def withHttp5xxThreshold(http5xxThreshold: Int,
                            severity: AlertSeverity = AlertSeverity.Critical,
-                           alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                           alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -122,7 +122,7 @@ case class AlertConfigBuilder(
                               threshold: Int,
                               lessThanMode: Boolean = false,
                               severity: AlertSeverity = AlertSeverity.Critical,
-                              alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                              alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
   def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
@@ -236,7 +236,7 @@ case class AlertConfigBuilder(
              |"metricsThresholds" : ${printSeq(metricsThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu))(
               MetricsThresholdProtocol.thresholdFormat)},
              |"total-http-request-threshold": $updatedTotalHttpRequestThreshold,
-             |"log-message-thresholds" : ${logMessageThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
+             |"log-message-thresholds" : ${logMessageThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).toJson.compactPrint},
              |"average-cpu-threshold" : $updatedAverageCPUThreshold,
              |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds)(
               HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
@@ -365,7 +365,7 @@ case class TeamAlertConfigBuilder(
                               threshold: Int,
                               lessThanMode: Boolean = false,
                               severity: AlertSeverity = AlertSeverity.Critical,
-                              alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                              alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
   def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -229,7 +229,7 @@ case class AlertConfigBuilder(
              |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption
               .map(_.toJson.compactPrint)
               .getOrElse(JsNull)},
-             |"httpTrafficThresholds" : ${httpTrafficThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
+             |"httpTrafficThresholds" : ${httpTrafficThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold)).toJson.compactPrint},
              |"httpStatusThresholds" : ${httpStatusThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).toJson.compactPrint},
              |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).toJson.compactPrint},
              |"http5xxRateIncrease" : ${printSeq(http5xxRateIncrease)(Http5xxRateIncreaseProtocol.rateIncreaseFormat)},

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -231,7 +231,7 @@ case class AlertConfigBuilder(
               .getOrElse(JsNull)},
              |"httpTrafficThresholds" : ${httpTrafficThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
              |"httpStatusThresholds" : ${httpStatusThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
-             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
+             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).toJson.compactPrint},
              |"http5xxRateIncrease" : ${printSeq(http5xxRateIncrease)(Http5xxRateIncreaseProtocol.rateIncreaseFormat)},
              |"metricsThresholds" : ${printSeq(metricsThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu))(
               MetricsThresholdProtocol.thresholdFormat)},

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -72,7 +72,7 @@ case class AlertConfigBuilder(
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   severity: AlertSeverity = AlertSeverity.Critical,
-                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform = alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
@@ -162,7 +162,7 @@ case class AlertConfigBuilder(
           a.toJson.compactPrint
 
         ZoneToServiceDomainMapper.getServiceDomain(serviceDomain, platformService).map { serviceDomain =>
-          val updated5xxPercentThreshold = if (http5xxPercentThreshold.alertingPlatform != AlertingPlatform.Sensu) {
+          val updated5xxPercentThreshold = if (isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold)) {
             333.33
           } else {
             http5xxPercentThreshold.percentage
@@ -311,7 +311,7 @@ case class TeamAlertConfigBuilder(
 
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   severity: AlertSeverity = AlertSeverity.Critical,
-                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                                  alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -115,7 +115,7 @@ case class AlertConfigBuilder(
   def withContainerKillThreshold(containerCrashThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerCrashThreshold, alertingPlatform))
 
-  def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+  def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold, alertingPlatform))
 
   def withLogMessageThreshold(message: String,
@@ -202,7 +202,7 @@ case class AlertConfigBuilder(
             exceptionThreshold.count
           }
 
-          val updatedTotalHttpRequestThreshold = if (totalHttpRequestThreshold.alertingPlatform != AlertingPlatform.Sensu) {
+          val updatedTotalHttpRequestThreshold = if (isGrafanaEnabled(totalHttpRequestThreshold.alertingPlatform, currentEnvironment, AlertType.TotalHttpRequestThreshold)) {
             Int.MaxValue
           } else {
             totalHttpRequestThreshold.count
@@ -358,7 +358,7 @@ case class TeamAlertConfigBuilder(
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
 
-  def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+  def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold, alertingPlatform))
 
   def withLogMessageThreshold(message: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -112,7 +112,7 @@ case class AlertConfigBuilder(
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
 
-  def withContainerKillThreshold(containerCrashThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+  def withContainerKillThreshold(containerCrashThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerCrashThreshold, alertingPlatform))
 
   def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
@@ -182,7 +182,7 @@ case class AlertConfigBuilder(
             averageCPUThreshold.count
           }
 
-          val updatedContainerKillThreshold = if (containerKillThreshold.alertingPlatform != AlertingPlatform.Sensu) {
+          val updatedContainerKillThreshold = if (isGrafanaEnabled(containerKillThreshold.alertingPlatform, currentEnvironment, AlertType.ContainerKillThreshold)) {
             Int.MaxValue
           } else {
             containerKillThreshold.count
@@ -335,7 +335,7 @@ case class TeamAlertConfigBuilder(
   def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold) =
     this.copy(httpAbsolutePercentSplitDownstreamHodThresholds = httpAbsolutePercentSplitDownstreamHodThresholds :+ threshold)
 
-  def withContainerKillThreshold(containerKillThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+  def withContainerKillThreshold(containerKillThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerKillThreshold, alertingPlatform))
 
   def withHttpTrafficThreshold(threshold: HttpTrafficThreshold) = {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -57,7 +57,7 @@ case class AlertConfigBuilder(
   def withHandlers(handlers: String*) =
     this.copy(handlers = handlers)
 
-  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold, alertingPlatform))
 
   def withExceptionThreshold(exceptionThreshold: Int,
@@ -188,7 +188,7 @@ case class AlertConfigBuilder(
             containerKillThreshold.count
           }
 
-          val updatedErrorsLoggedThreshold = if (errorsLoggedThreshold.alertingPlatform != AlertingPlatform.Sensu) {
+          val updatedErrorsLoggedThreshold = if (isGrafanaEnabled(errorsLoggedThreshold.alertingPlatform, currentEnvironment, AlertType.ErrorsLoggedThreshold)) {
             Int.MaxValue
           } else {
             errorsLoggedThreshold.count
@@ -296,7 +296,7 @@ case class TeamAlertConfigBuilder(
   def withHandlers(handlers: String*) =
     this.copy(handlers = handlers)
 
-  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold, alertingPlatform))
 
   def withExceptionThreshold(exceptionThreshold: Int,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -62,7 +62,7 @@ case class AlertConfigBuilder(
 
   def withExceptionThreshold(exceptionThreshold: Int,
                              severity: AlertSeverity = AlertSeverity.Critical,
-                             alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                             alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity, alertingPlatform = alertingPlatform))
 
   def withHttp5xxThreshold(http5xxThreshold: Int,
@@ -194,7 +194,7 @@ case class AlertConfigBuilder(
             errorsLoggedThreshold.count
           }
 
-          val updatedExceptionThreshold = if (exceptionThreshold.alertingPlatform != AlertingPlatform.Sensu) {
+          val updatedExceptionThreshold = if (isGrafanaEnabled(exceptionThreshold.alertingPlatform, currentEnvironment, AlertType.ExceptionThreshold)) {
             // if this alert is configured to use NOT Sensu, then set it to an unreasonably high threshold so
             // it will never be triggered
             Int.MaxValue
@@ -301,7 +301,7 @@ case class TeamAlertConfigBuilder(
 
   def withExceptionThreshold(exceptionThreshold: Int,
                              severity: AlertSeverity = AlertSeverity.Critical,
-                             alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu) =
+                             alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity, alertingPlatform = alertingPlatform))
 
   def withHttp5xxThreshold(http5xxThreshold: Int,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -230,7 +230,7 @@ case class AlertConfigBuilder(
               .map(_.toJson.compactPrint)
               .getOrElse(JsNull)},
              |"httpTrafficThresholds" : ${httpTrafficThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
-             |"httpStatusThresholds" : ${httpStatusThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu).toJson.compactPrint},
+             |"httpStatusThresholds" : ${httpStatusThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).toJson.compactPrint},
              |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).toJson.compactPrint},
              |"http5xxRateIncrease" : ${printSeq(http5xxRateIncrease)(Http5xxRateIncreaseProtocol.rateIncreaseFormat)},
              |"metricsThresholds" : ${printSeq(metricsThresholds.filter(_.alertingPlatform == AlertingPlatform.Sensu))(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
@@ -18,5 +18,5 @@ package uk.gov.hmrc.alertconfig.builder
 
 case class ContainerKillThreshold(
     count: Int = Int.MaxValue,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ErrorsLoggedThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ErrorsLoggedThreshold.scala
@@ -18,5 +18,5 @@ package uk.gov.hmrc.alertconfig.builder
 
 case class ErrorsLoggedThreshold(
     count: Int = Int.MaxValue,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
@@ -21,7 +21,7 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 case class ExceptionThreshold(
     count: Int = 2,
     severity: AlertSeverity = AlertSeverity.Critical,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object ExceptionThresholdProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -50,7 +50,7 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Sensu
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
     ),
 
     Environment.Development -> Map(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -49,7 +49,7 @@ object GrafanaMigration {
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold -> AlertingPlatform.Sensu,
+      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Sensu
     ),
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -43,7 +43,7 @@ object GrafanaMigration {
       AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
       AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Sensu,
+      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Sensu,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -48,7 +48,7 @@ object GrafanaMigration {
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,
+      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Sensu,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Sensu
     ),

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -45,7 +45,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Sensu,
+      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
       AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -44,7 +44,7 @@ object GrafanaMigration {
       AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold -> AlertingPlatform.Sensu,
+      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -40,7 +40,7 @@ object GrafanaMigration {
   val config = Map(
     Environment.Integration -> Map(
       AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Sensu,
+      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
       AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Sensu,
       AlertType.ExceptionThreshold -> AlertingPlatform.Sensu,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Sensu,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -41,7 +41,7 @@ object GrafanaMigration {
     Environment.Integration -> Map(
       AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
       AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Sensu,
+      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
       AlertType.ExceptionThreshold -> AlertingPlatform.Sensu,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Sensu,
       AlertType.Http5xxThreshold -> AlertingPlatform.Sensu,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -46,7 +46,7 @@ object GrafanaMigration {
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Sensu,
+      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
       AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,
       AlertType.MetricsThreshold -> AlertingPlatform.Sensu,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -42,7 +42,7 @@ object GrafanaMigration {
       AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
       AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
       AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Sensu,
+      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Sensu,
       AlertType.Http5xxThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Sensu,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -47,7 +47,7 @@ object GrafanaMigration {
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
+      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,
       AlertType.MetricsThreshold -> AlertingPlatform.Sensu,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Sensu

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -21,7 +21,7 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 case class Http5xxPercentThreshold(
     percentage: Double = 100.0,
     severity: AlertSeverity = AlertSeverity.Critical,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object Http5xxPercentThresholdProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
@@ -21,7 +21,7 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 case class Http5xxThreshold(
     count: Int = Int.MaxValue,
     severity: AlertSeverity = AlertSeverity.Critical,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object Http5xxThresholdProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusPercentThreshold.scala
@@ -23,7 +23,7 @@ case class HttpStatusPercentThreshold(
     percentage: Double = 100.0,
     severity: AlertSeverity = AlertSeverity.Critical,
     httpMethod: HttpMethod = HttpMethod.All,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object HttpStatusPercentThresholdProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
@@ -23,7 +23,7 @@ case class HttpStatusThreshold(
     count: Int = 1,
     severity: AlertSeverity = AlertSeverity.Critical,
     httpMethod: HttpMethod = HttpMethod.All,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object HttpStatusThresholdProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpTrafficThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpTrafficThreshold.scala
@@ -22,7 +22,7 @@ case class HttpTrafficThreshold(
     warning: Option[Int],
     critical: Option[Int],
     maxMinutesBelowThreshold: Int = 5,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object HttpTrafficThresholdProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
@@ -24,7 +24,7 @@ case class LogMessageThreshold(
     count: Int,
     lessThanMode: Boolean = false,
     severity: AlertSeverity = AlertSeverity.Critical,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object LogMessageThresholdProtocol extends {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/MetricsThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/MetricsThreshold.scala
@@ -24,7 +24,7 @@ case class MetricsThreshold(
     warning: Option[Double] = None,
     critical: Option[Double] = None,
     invert: Boolean = false,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object MetricsThresholdProtocol extends DefaultJsonProtocol {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
@@ -18,5 +18,5 @@ package uk.gov.hmrc.alertconfig.builder
 
 case class TotalHttpRequestThreshold(
     count: Int = Int.MaxValue,
-    alertingPlatform: AlertingPlatform = AlertingPlatform.Sensu
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
@@ -77,16 +77,16 @@ object YamlBuilder {
     Alerts(
       averageCPUThreshold = convertAverageCPUThreshold(alertConfigBuilder.averageCPUThreshold, currentEnvironment),
       containerKillThreshold = convertContainerKillThreshold(alertConfigBuilder.containerKillThreshold, currentEnvironment),
-      errorsLoggedThreshold = convertErrorsLoggedThreshold(alertConfigBuilder.errorsLoggedThreshold),
-      exceptionThreshold = convertExceptionThreshold(alertConfigBuilder.exceptionThreshold),
-      http5xxPercentThreshold = convertHttp5xxPercentThresholds(alertConfigBuilder.http5xxPercentThreshold),
-      http5xxThreshold = convertHttp5xxThreshold(alertConfigBuilder.http5xxThreshold),
-      httpStatusPercentThresholds = convertHttpStatusPercentThresholdAlerts(alertConfigBuilder.httpStatusPercentThresholds),
-      httpStatusThresholds = convertHttpStatusThresholds(alertConfigBuilder.httpStatusThresholds),
-      httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds),
-      logMessageThresholds = convertLogMessageThresholdAlerts(alertConfigBuilder.logMessageThresholds),
-      totalHttpRequestThreshold = convertTotalHttpRequestThreshold(alertConfigBuilder.totalHttpRequestThreshold),
-      metricsThresholds = convertMetricsThreshold(alertConfigBuilder.metricsThresholds)
+      errorsLoggedThreshold = convertErrorsLoggedThreshold(alertConfigBuilder.errorsLoggedThreshold, currentEnvironment),
+      exceptionThreshold = convertExceptionThreshold(alertConfigBuilder.exceptionThreshold, currentEnvironment),
+      http5xxPercentThreshold = convertHttp5xxPercentThresholds(alertConfigBuilder.http5xxPercentThreshold, currentEnvironment),
+      http5xxThreshold = convertHttp5xxThreshold(alertConfigBuilder.http5xxThreshold, currentEnvironment),
+      httpStatusPercentThresholds = convertHttpStatusPercentThresholdAlerts(alertConfigBuilder.httpStatusPercentThresholds, currentEnvironment),
+      httpStatusThresholds = convertHttpStatusThresholds(alertConfigBuilder.httpStatusThresholds, currentEnvironment),
+      httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds, currentEnvironment),
+      logMessageThresholds = convertLogMessageThresholdAlerts(alertConfigBuilder.logMessageThresholds, currentEnvironment),
+      totalHttpRequestThreshold = convertTotalHttpRequestThreshold(alertConfigBuilder.totalHttpRequestThreshold, currentEnvironment),
+      metricsThresholds = convertMetricsThreshold(alertConfigBuilder.metricsThresholds, currentEnvironment)
     )
   }
 
@@ -97,19 +97,19 @@ object YamlBuilder {
   }
 
   def convertContainerKillThreshold(containerKillThreshold: ContainerKillThreshold, currentEnvironment: Environment): Option[YamlContainerKillThresholdAlert] = {
-    Option.when(isGrafanaEnabled(containerKillThreshold.alertingPlatform, currentEnvironment, AlertType.AverageCPUThreshold) && containerKillThreshold.count < Int.MaxValue)(
+    Option.when(isGrafanaEnabled(containerKillThreshold.alertingPlatform, currentEnvironment, AlertType.ContainerKillThreshold) && containerKillThreshold.count < Int.MaxValue)(
       YamlContainerKillThresholdAlert(containerKillThreshold.count)
     )
   }
 
-  def convertErrorsLoggedThreshold(errorsLoggedThreshold: ErrorsLoggedThreshold): Option[YamlErrorsLoggedThresholdAlert] = {
-    Option.when(errorsLoggedThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+  def convertErrorsLoggedThreshold(errorsLoggedThreshold: ErrorsLoggedThreshold, currentEnvironment: Environment): Option[YamlErrorsLoggedThresholdAlert] = {
+    Option.when(isGrafanaEnabled(errorsLoggedThreshold.alertingPlatform , currentEnvironment, AlertType.ErrorsLoggedThreshold))(
       YamlErrorsLoggedThresholdAlert(errorsLoggedThreshold.count)
     )
   }
 
-  def convertExceptionThreshold(exceptionThreshold: ExceptionThreshold): Option[YamlExceptionThresholdAlert] = {
-    Option.when(exceptionThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+  def convertExceptionThreshold(exceptionThreshold: ExceptionThreshold, currentEnvironment: Environment): Option[YamlExceptionThresholdAlert] = {
+    Option.when(isGrafanaEnabled(exceptionThreshold.alertingPlatform, currentEnvironment, AlertType.ExceptionThreshold))(
       YamlExceptionThresholdAlert(
         count = exceptionThreshold.count,
         severity = exceptionThreshold.severity.toString
@@ -117,8 +117,8 @@ object YamlBuilder {
     )
   }
 
-  def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Http5xxPercentThreshold): Option[YamlHttp5xxPercentThresholdAlert] = {
-    Option.when(http5xxPercentThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+  def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Http5xxPercentThreshold, currentEnvironment: Environment): Option[YamlHttp5xxPercentThresholdAlert] = {
+    Option.when(isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold))(
       YamlHttp5xxPercentThresholdAlert(
         percentage = http5xxPercentThreshold.percentage,
         severity = http5xxPercentThreshold.severity.toString
@@ -126,8 +126,8 @@ object YamlBuilder {
     )
   }
 
-  def convertHttp5xxThreshold(http5xxThreshold: Http5xxThreshold): Option[YamlHttp5xxThresholdAlert] = {
-    Option.when(http5xxThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+  def convertHttp5xxThreshold(http5xxThreshold: Http5xxThreshold, currentEnvironment: Environment): Option[YamlHttp5xxThresholdAlert] = {
+    Option.when(isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold))(
       YamlHttp5xxThresholdAlert(
         count = http5xxThreshold.count,
         severity = http5xxThreshold.severity.toString
@@ -135,8 +135,8 @@ object YamlBuilder {
     )
   }
 
-  def convertHttpStatusThresholds(httpStatusThresholds: Seq[HttpStatusThreshold]): Option[Seq[YamlHttpStatusThresholdAlert]] = {
-    val converted = httpStatusThresholds.withFilter(_.alertingPlatform == Grafana).map { threshold =>
+  def convertHttpStatusThresholds(httpStatusThresholds: Seq[HttpStatusThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpStatusThresholdAlert]] = {
+    val converted = httpStatusThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).map { threshold =>
       YamlHttpStatusThresholdAlert(
         count = threshold.count,
         httpMethod = threshold.httpMethod.toString,
@@ -147,8 +147,8 @@ object YamlBuilder {
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertLogMessageThresholdAlerts(logMessageThresholds: Seq[LogMessageThreshold]): Option[Seq[YamlLogMessageThresholdAlert]] = {
-    val converted = logMessageThresholds.withFilter(_.alertingPlatform == Grafana).map { threshold =>
+  def convertLogMessageThresholdAlerts(logMessageThresholds: Seq[LogMessageThreshold], currentEnvironment: Environment): Option[Seq[YamlLogMessageThresholdAlert]] = {
+    val converted = logMessageThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).map { threshold =>
       YamlLogMessageThresholdAlert(
         message = threshold.message,
         count = threshold.count,
@@ -160,8 +160,8 @@ object YamlBuilder {
   }
 
   def convertHttpStatusPercentThresholdAlerts(
-                                               httpStatusPercentThresholds: Seq[HttpStatusPercentThreshold]): Option[Seq[YamlHttpStatusPercentThresholdAlert]] = {
-    val converted = httpStatusPercentThresholds.withFilter(_.alertingPlatform == Grafana).map { threshold =>
+                                               httpStatusPercentThresholds: Seq[HttpStatusPercentThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpStatusPercentThresholdAlert]] = {
+    val converted = httpStatusPercentThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).map { threshold =>
       YamlHttpStatusPercentThresholdAlert(
         percentage = threshold.percentage,
         httpMethod = threshold.httpMethod.toString,
@@ -172,9 +172,9 @@ object YamlBuilder {
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertHttpTrafficThresholds(httpTrafficThresholds: Seq[HttpTrafficThreshold]): Option[Seq[YamlHttpTrafficThresholdAlert]] = {
+  def convertHttpTrafficThresholds(httpTrafficThresholds: Seq[HttpTrafficThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpTrafficThresholdAlert]] = {
     val converted = httpTrafficThresholds.flatMap { threshold =>
-      if (threshold.alertingPlatform == Grafana) {
+      if (isGrafanaEnabled(threshold.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold)) {
         Seq(
           threshold.warning.map { warningCount =>
             YamlHttpTrafficThresholdAlert(
@@ -198,15 +198,15 @@ object YamlBuilder {
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertTotalHttpRequestThreshold(totalHttpRequestThreshold: TotalHttpRequestThreshold): Option[YamlTotalHttpRequestThresholdAlert] = {
-    Option.when(totalHttpRequestThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+  def convertTotalHttpRequestThreshold(totalHttpRequestThreshold: TotalHttpRequestThreshold, currentEnvironment: Environment): Option[YamlTotalHttpRequestThresholdAlert] = {
+    Option.when(isGrafanaEnabled(totalHttpRequestThreshold.alertingPlatform, currentEnvironment, AlertType.TotalHttpRequestThreshold))(
       YamlTotalHttpRequestThresholdAlert(totalHttpRequestThreshold.count)
     )
   }
 
-  def convertMetricsThreshold(metricsThreshold: Seq[MetricsThreshold]): Option[Seq[YamlMetricsThresholdAlert]] = {
+  def convertMetricsThreshold(metricsThreshold: Seq[MetricsThreshold], currentEnvironment: Environment): Option[Seq[YamlMetricsThresholdAlert]] = {
     val converted = metricsThreshold.flatMap { threshold =>
-      if (threshold.alertingPlatform == Grafana) {
+      if (isGrafanaEnabled(threshold.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)) {
         Seq(
           threshold.warning.map { warningCount =>
             YamlMetricsThresholdAlert(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
@@ -76,7 +76,7 @@ object YamlBuilder {
   def convertAlerts(alertConfigBuilder: AlertConfigBuilder, currentEnvironment: Environment): Alerts = {
     Alerts(
       averageCPUThreshold = convertAverageCPUThreshold(alertConfigBuilder.averageCPUThreshold, currentEnvironment),
-      containerKillThreshold = convertContainerKillThreshold(alertConfigBuilder.containerKillThreshold),
+      containerKillThreshold = convertContainerKillThreshold(alertConfigBuilder.containerKillThreshold, currentEnvironment),
       errorsLoggedThreshold = convertErrorsLoggedThreshold(alertConfigBuilder.errorsLoggedThreshold),
       exceptionThreshold = convertExceptionThreshold(alertConfigBuilder.exceptionThreshold),
       http5xxPercentThreshold = convertHttp5xxPercentThresholds(alertConfigBuilder.http5xxPercentThreshold),
@@ -96,8 +96,8 @@ object YamlBuilder {
     )
   }
 
-  def convertContainerKillThreshold(containerKillThreshold: ContainerKillThreshold): Option[YamlContainerKillThresholdAlert] = {
-    Option.when(containerKillThreshold.alertingPlatform == AlertingPlatform.Grafana)(
+  def convertContainerKillThreshold(containerKillThreshold: ContainerKillThreshold, currentEnvironment: Environment): Option[YamlContainerKillThresholdAlert] = {
+    Option.when(isGrafanaEnabled(containerKillThreshold.alertingPlatform, currentEnvironment, AlertType.AverageCPUThreshold) && containerKillThreshold.count < Int.MaxValue)(
       YamlContainerKillThresholdAlert(containerKillThreshold.count)
     )
   }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
@@ -103,13 +103,13 @@ object YamlBuilder {
   }
 
   def convertErrorsLoggedThreshold(errorsLoggedThreshold: ErrorsLoggedThreshold, currentEnvironment: Environment): Option[YamlErrorsLoggedThresholdAlert] = {
-    Option.when(isGrafanaEnabled(errorsLoggedThreshold.alertingPlatform , currentEnvironment, AlertType.ErrorsLoggedThreshold))(
+    Option.when(isGrafanaEnabled(errorsLoggedThreshold.alertingPlatform , currentEnvironment, AlertType.ErrorsLoggedThreshold) && errorsLoggedThreshold.count < Int.MaxValue)(
       YamlErrorsLoggedThresholdAlert(errorsLoggedThreshold.count)
     )
   }
 
   def convertExceptionThreshold(exceptionThreshold: ExceptionThreshold, currentEnvironment: Environment): Option[YamlExceptionThresholdAlert] = {
-    Option.when(isGrafanaEnabled(exceptionThreshold.alertingPlatform, currentEnvironment, AlertType.ExceptionThreshold))(
+    Option.when(isGrafanaEnabled(exceptionThreshold.alertingPlatform, currentEnvironment, AlertType.ExceptionThreshold) && exceptionThreshold.count < Int.MaxValue)(
       YamlExceptionThresholdAlert(
         count = exceptionThreshold.count,
         severity = exceptionThreshold.severity.toString
@@ -118,7 +118,7 @@ object YamlBuilder {
   }
 
   def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Http5xxPercentThreshold, currentEnvironment: Environment): Option[YamlHttp5xxPercentThresholdAlert] = {
-    Option.when(isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold))(
+    Option.when(isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold) && http5xxPercentThreshold.percentage <= 100.0)(
       YamlHttp5xxPercentThresholdAlert(
         percentage = http5xxPercentThreshold.percentage,
         severity = http5xxPercentThreshold.severity.toString
@@ -127,7 +127,7 @@ object YamlBuilder {
   }
 
   def convertHttp5xxThreshold(http5xxThreshold: Http5xxThreshold, currentEnvironment: Environment): Option[YamlHttp5xxThresholdAlert] = {
-    Option.when(isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold))(
+    Option.when(isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold) && http5xxThreshold.count < Int.MaxValue)(
       YamlHttp5xxThresholdAlert(
         count = http5xxThreshold.count,
         severity = http5xxThreshold.severity.toString
@@ -199,7 +199,7 @@ object YamlBuilder {
   }
 
   def convertTotalHttpRequestThreshold(totalHttpRequestThreshold: TotalHttpRequestThreshold, currentEnvironment: Environment): Option[YamlTotalHttpRequestThresholdAlert] = {
-    Option.when(isGrafanaEnabled(totalHttpRequestThreshold.alertingPlatform, currentEnvironment, AlertType.TotalHttpRequestThreshold))(
+    Option.when(isGrafanaEnabled(totalHttpRequestThreshold.alertingPlatform, currentEnvironment, AlertType.TotalHttpRequestThreshold) && totalHttpRequestThreshold.count < Int.MaxValue)(
       YamlTotalHttpRequestThresholdAlert(totalHttpRequestThreshold.count)
     )
   }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import uk.gov.hmrc.alertconfig.builder.AlertingPlatform.Grafana
 import uk.gov.hmrc.alertconfig.builder.GrafanaMigration.isGrafanaEnabled
 import uk.gov.hmrc.alertconfig.builder.{AlertConfig, AlertConfigBuilder, AlertType, AlertingPlatform, AverageCPUThreshold, ContainerKillThreshold, Environment, ErrorsLoggedThreshold, ExceptionThreshold, Http5xxPercentThreshold, Http5xxThreshold, HttpStatusPercentThreshold, HttpStatusThreshold, HttpTrafficThreshold, LogMessageThreshold, Logger, MetricsThreshold, TotalHttpRequestThreshold}
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -45,7 +45,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("exception-threshold") shouldBe JsObject(
         "count"            -> JsNumber(2),
         "severity"         -> JsString("critical"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       config("5xx-threshold") shouldBe JsObject(
         "count"            -> JsNumber(Int.MaxValue),
@@ -592,7 +592,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     val expected = JsObject(
       "severity"         -> JsString("critical"),
       "count"            -> JsNumber(threshold),
-      "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+      "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
 
     serviceConfig("exception-threshold") shouldBe expected
@@ -630,7 +630,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     val expected = JsObject(
       "severity"         -> JsString("warning"),
       "count"            -> JsNumber(threshold),
-      "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+      "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
 
     serviceConfig("exception-threshold") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -50,7 +50,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("5xx-threshold") shouldBe JsObject(
         "count"            -> JsNumber(Int.MaxValue),
         "severity"         -> JsString("critical"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
@@ -264,7 +264,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       serviceConfig("5xx-threshold") shouldBe JsObject(
         "count"            -> JsNumber(2),
         "severity"         -> JsString("critical"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString))
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
     }
 
     "configure logMessageThresholds with given thresholds only if alerting platform is Sensu" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -287,28 +287,28 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "count"            -> JsNumber(3),
           "lessThanMode"     -> JsFalse,
           "severity"         -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         ),
         JsObject(
           "message"          -> JsString("SIMULATED_ERROR2"),
           "count"            -> JsNumber(4),
           "lessThanMode"     -> JsFalse,
           "severity"         -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         ),
         JsObject(
           "message"          -> JsString("SIMULATED_ERROR3"),
           "count"            -> JsNumber(5),
           "lessThanMode"     -> JsTrue,
           "severity"         -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         ),
         JsObject(
           "message"          -> JsString("SIMULATED_ERROR4"),
           "count"            -> JsNumber(6),
           "lessThanMode"     -> JsTrue,
           "severity"         -> JsString("warning"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         )
       )
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -328,7 +328,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "warning"                  -> JsNumber(10),
           "critical"                 -> JsNumber(5),
           "maxMinutesBelowThreshold" -> JsNumber(35),
-          "alertingPlatform"         -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform"         -> JsString(AlertingPlatform.Default.toString)
         )
       )
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -417,26 +417,26 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "warning"     -> JsNumber(65.0),
           "critical"    -> JsNumber(88.0),
           "invert"      -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
         JsObject(
           "name" -> JsString("alert1-warning-only"),
           "query"  -> JsString(query),
           "warning"  -> JsNumber(44.0),
           "invert" -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
         JsObject(
           "name" -> JsString("alert1-critical-only"),
           "query" -> JsString(query),
           "critical" -> JsNumber(45.0),
           "invert" -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
         JsObject(
           "name"     -> JsString("alert2"),
           "query"    -> JsString(query),
           "warning"  -> JsNumber(30.03),
           "critical" -> JsNumber(12.21),
           "invert"   -> JsBoolean(true),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString))
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
       )
     }
 
@@ -460,7 +460,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "warning" -> JsNumber(65.0),
           "critical" -> JsNumber(88.0),
           "invert" -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)))
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)))
     }
 
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -55,7 +55,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
         "percentage"       -> JsNumber(100),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
       config("containerKillThreshold") shouldBe JsNumber(56)
@@ -675,7 +675,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
       "percentage"       -> JsNumber(threshold),
-      "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+      "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
   }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -195,13 +195,13 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "percentage"       -> JsNumber(2.2),
           "severity"         -> JsString("warning"),
           "httpMethod"       -> JsString("POST"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
         JsObject(
           "httpStatus"       -> JsNumber(504),
           "percentage"       -> JsNumber(4.4),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString))
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
       )
     }
 
@@ -233,7 +233,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "percentage"       -> JsNumber(100.0),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString))
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
       )
     }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -124,14 +124,14 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "count"            -> JsNumber(2),
           "severity"         -> JsString("warning"),
           "httpMethod"       -> JsString("POST"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         ),
         JsObject(
           "httpStatus"       -> JsNumber(504),
           "count"            -> JsNumber(4),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         )
       )
     }
@@ -154,7 +154,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "count"            -> JsNumber(4),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         )
       )
     }
@@ -174,7 +174,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "count"            -> JsNumber(1),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         )
       )
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -611,21 +611,21 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       val expected = JsArray(
         JsObject(
-          "alertingPlatform" -> JsString("Sensu"),
+          "alertingPlatform" -> JsString("Default"),
           "httpStatus"       -> JsNumber(500),
           "count"            -> JsNumber(19),
           "severity"         -> JsString("warning"),
           "httpMethod"       -> JsString("POST")
         ),
         JsObject(
-          "alertingPlatform" -> JsString("Sensu"),
+          "alertingPlatform" -> JsString("Default"),
           "httpStatus"       -> JsNumber(501),
           "count"            -> JsNumber(20),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS")
         ),
         JsObject(
-          "alertingPlatform" -> JsString("Sensu"),
+          "alertingPlatform" -> JsString("Default"),
           "httpStatus"       -> JsNumber(555),
           "count"            -> JsNumber(55),
           "severity"         -> JsString("critical"),

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -487,7 +487,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      val expected = JsObject("count" -> JsNumber(threshold), "severity" -> JsString("warning"), "alertingPlatform" -> JsString("Sensu"))
+      val expected = JsObject("count" -> JsNumber(threshold), "severity" -> JsString("warning"), "alertingPlatform" -> JsString("Default"))
 
       service1Config("5xx-threshold") shouldBe expected
       service2Config("5xx-threshold") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -775,21 +775,21 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "count"            -> JsNumber(19),
           "lessThanMode"     -> JsFalse,
           "severity"         -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         ),
         JsObject(
           "message"          -> JsString("SIMULATED_ERROR2"),
           "count"            -> JsNumber(20),
           "lessThanMode"     -> JsTrue,
           "severity"         -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         ),
         JsObject(
           "message"          -> JsString("SIMULATED_ERROR3"),
           "count"            -> JsNumber(21),
           "lessThanMode"     -> JsTrue,
           "severity"         -> JsString("warning"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
         )
       )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -323,12 +323,12 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       service1Config("exception-threshold") shouldBe JsObject(
         "count"            -> JsNumber(threshold),
         "severity"         -> JsString("warning"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("exception-threshold") shouldBe JsObject(
         "count"            -> JsNumber(threshold),
         "severity"         -> JsString("warning"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
     }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -663,19 +663,19 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "percentage"       -> JsNumber(19.1),
           "severity"         -> JsString("warning"),
           "httpMethod"       -> JsString("POST"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
         JsObject(
           "httpStatus"       -> JsNumber(501),
           "percentage"       -> JsNumber(20),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
         JsObject(
           "httpStatus"       -> JsNumber(555),
           "percentage"       -> JsNumber(55.5),
           "severity"         -> JsString("critical"),
           "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString))
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
       )
 
       service1Config("httpStatusPercentThresholds") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -45,7 +45,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       alertConfigBuilder.httpStatusThresholds shouldBe List()
       alertConfigBuilder.httpTrafficThresholds shouldBe List()
       alertConfigBuilder.logMessageThresholds shouldBe List()
-      alertConfigBuilder.totalHttpRequestThreshold shouldBe TotalHttpRequestThreshold(Int.MaxValue, AlertingPlatform.Sensu)
+      alertConfigBuilder.totalHttpRequestThreshold shouldBe TotalHttpRequestThreshold(Int.MaxValue, AlertingPlatform.Default)
     }
 
     "result in identical defaults to AlertConfigBuilder" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -36,7 +36,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
       alertConfigBuilder.handlers shouldBe Seq("noop")
       alertConfigBuilder.averageCPUThreshold shouldBe AverageCPUThreshold(Int.MaxValue, AlertingPlatform.Default)
-      alertConfigBuilder.containerKillThreshold shouldBe ContainerKillThreshold(1, AlertingPlatform.Sensu)
+      alertConfigBuilder.containerKillThreshold shouldBe ContainerKillThreshold(1, AlertingPlatform.Default)
       alertConfigBuilder.exceptionThreshold shouldBe ExceptionThreshold(2, AlertSeverity.Critical)
       alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(100, AlertSeverity.Critical)
       alertConfigBuilder.http5xxThreshold shouldBe Http5xxThreshold(Int.MaxValue, AlertSeverity.Critical)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -558,7 +558,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "warning"                  -> JsNumber(10),
           "critical"                 -> JsNumber(5),
           "maxMinutesBelowThreshold" -> JsNumber(35),
-          "alertingPlatform"         -> JsString("Sensu")
+          "alertingPlatform"         -> JsString("Default")
         )
       )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -272,12 +272,12 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
         "percentage"       -> JsNumber(threshold),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
         "percentage"       -> JsNumber(threshold),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
     }
 
@@ -730,7 +730,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(12.2),
         "severity"         -> JsString("warning"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Sensu.toString)
+        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
     }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -74,6 +74,15 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       output.containerKillThreshold shouldBe Some(YamlContainerKillThresholdAlert(60))
     }
 
+    "containerKillThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withContainerKillThreshold(60, AlertingPlatform.Sensu)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.containerKillThreshold shouldBe None
+    }
+
     "containerKillThreshold should be enabled by default in integration" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withContainerKillThreshold(60)
@@ -92,13 +101,40 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       output.containerKillThreshold shouldBe None
     }
 
-    "containerKillThreshold should be disabled if alertingPlatform is Sensu" in {
+    "ErrorsLoggedThreshold should be enabled if alertingPlatform is Grafana" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
-        .withAverageCPUThreshold(60, AlertingPlatform.Sensu)
+        .withErrorsLoggedThreshold(60, AlertingPlatform.Grafana)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.errorsLoggedThreshold shouldBe Some(YamlErrorsLoggedThresholdAlert(60))
+    }
+
+    "ErrorsLoggedThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withErrorsLoggedThreshold(60, AlertingPlatform.Sensu)
 
       val output = YamlBuilder.convertAlerts(config, Environment.Integration)
 
-      output.averageCPUThreshold shouldBe None
+      output.errorsLoggedThreshold shouldBe None
+    }
+
+    "ErrorsLoggedThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withErrorsLoggedThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.errorsLoggedThreshold shouldBe Some(YamlErrorsLoggedThresholdAlert(60))
+    }
+
+    "ErrorsLoggedThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withErrorsLoggedThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.errorsLoggedThreshold shouldBe None
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -64,5 +64,41 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       output.averageCPUThreshold shouldBe None
     }
+
+    "containerKillThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withContainerKillThreshold(60, AlertingPlatform.Grafana)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.containerKillThreshold shouldBe Some(YamlContainerKillThresholdAlert(60))
+    }
+
+    "containerKillThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withContainerKillThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.containerKillThreshold shouldBe Some(YamlContainerKillThresholdAlert(60))
+    }
+
+    "containerKillThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withContainerKillThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.containerKillThreshold shouldBe None
+    }
+
+    "containerKillThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withAverageCPUThreshold(60, AlertingPlatform.Sensu)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.averageCPUThreshold shouldBe None
+    }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.alertconfig.builder.yaml
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.alertconfig.builder.{AlertConfigBuilder, AlertingPlatform, Environment}
+import uk.gov.hmrc.alertconfig.builder.HttpStatus.HTTP_STATUS
+import uk.gov.hmrc.alertconfig.builder.{AlertConfigBuilder, AlertingPlatform, Environment, HttpStatusPercentThreshold, HttpStatusThreshold, HttpTrafficThreshold, MetricsThreshold}
 
 class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
@@ -135,6 +136,294 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val output = YamlBuilder.convertAlerts(config, Environment.Production)
 
       output.errorsLoggedThreshold shouldBe None
+    }
+
+    "ExceptionThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withExceptionThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.exceptionThreshold shouldBe Some(YamlExceptionThresholdAlert(60, "critical"))
+    }
+
+    "ExceptionThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withExceptionThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.exceptionThreshold shouldBe None
+    }
+
+    "ExceptionThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withExceptionThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.exceptionThreshold shouldBe Some(YamlExceptionThresholdAlert(60, "critical"))
+    }
+
+    "ExceptionThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withExceptionThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.exceptionThreshold shouldBe None
+    }
+
+    "Http5xxPercentThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxPercentThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, "critical"))
+    }
+
+    "Http5xxPercentThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxPercentThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.http5xxPercentThreshold shouldBe None
+    }
+
+    "Http5xxPercentThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxPercentThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, "critical"))
+    }
+
+    "Http5xxPercentThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxPercentThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.http5xxPercentThreshold shouldBe None
+    }
+
+    "Http5xxThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.http5xxThreshold shouldBe Some(YamlHttp5xxThresholdAlert(60, "critical"))
+    }
+
+    "Http5xxThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.http5xxThreshold shouldBe None
+    }
+
+    "Http5xxThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.http5xxThreshold shouldBe Some(YamlHttp5xxThresholdAlert(60, "critical"))
+    }
+
+    "Http5xxThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxPercentThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.http5xxThreshold shouldBe None
+    }
+
+    "HttpStatusPercentThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Grafana))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.httpStatusPercentThresholds shouldBe Some(List(YamlHttpStatusPercentThresholdAlert(60, "ALL_METHODS", 500, "critical")))
+    }
+
+    "HttpStatusPercentThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Sensu))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpStatusPercentThresholds shouldBe None
+    }
+
+    "HttpStatusPercentThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpStatusPercentThresholds shouldBe Some(List(YamlHttpStatusPercentThresholdAlert(60, "ALL_METHODS", 500, "critical")))
+    }
+
+    "HttpStatusPercentThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.httpStatusPercentThresholds shouldBe None
+    }
+
+    "HttpStatusThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Grafana))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.httpStatusThresholds shouldBe Some(List(YamlHttpStatusThresholdAlert(60, "ALL_METHODS", 500, "critical")))
+    }
+
+    "HttpStatusThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Sensu))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpStatusThresholds shouldBe None
+    }
+
+    "HttpStatusThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpStatusThresholds shouldBe Some(List(YamlHttpStatusThresholdAlert(60, "ALL_METHODS", 500, "critical")))
+    }
+
+    "HttpStatusThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.httpStatusThresholds shouldBe None
+    }
+
+    "HttpTrafficThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60), alertingPlatform = AlertingPlatform.Grafana))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.httpTrafficThresholds shouldBe Some(List(YamlHttpTrafficThresholdAlert(60, 5, "critical")))
+    }
+
+    "HttpTrafficThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60), alertingPlatform = AlertingPlatform.Sensu))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpTrafficThresholds shouldBe None
+    }
+
+    "HttpTrafficThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60)))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpTrafficThresholds shouldBe Some(List(YamlHttpTrafficThresholdAlert(60, 5, "critical")))
+    }
+
+    "HttpTrafficThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60)))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.httpTrafficThresholds shouldBe None
+    }
+
+    "LogMessageThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withLogMessageThreshold("LOG_MESSAGE", 60, alertingPlatform = AlertingPlatform.Grafana)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(60, false, "LOG_MESSAGE", "critical")))
+    }
+
+    "LogMessageThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withLogMessageThreshold("LOG_MESSAGE", 60, alertingPlatform = AlertingPlatform.Sensu)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.logMessageThresholds shouldBe None
+    }
+
+    "LogMessageThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withLogMessageThreshold("LOG_MESSAGE", 60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(60, false, "LOG_MESSAGE", "critical")))
+    }
+
+    "LogMessageThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withLogMessageThreshold("LOG_MESSAGE", 60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.logMessageThresholds shouldBe None
+    }
+
+    "MetricsThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1), alertingPlatform = AlertingPlatform.Grafana))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(1, "metric", "a.b.c.d", "critical", false)))
+    }
+
+    "MetricsThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1), alertingPlatform = AlertingPlatform.Sensu))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.metricsThresholds shouldBe None
+    }
+
+    "MetricsThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1)))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(1, "metric", "a.b.c.d", "critical", false)))
+    }
+
+    "MetricsThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1)))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.metricsThresholds shouldBe None
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -425,5 +425,41 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       output.metricsThresholds shouldBe None
     }
+
+    "TotalHttpRequestThreshold should be enabled if alertingPlatform is Grafana" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withTotalHttpRequestsCountThreshold(60, AlertingPlatform.Grafana)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
+    }
+
+    "TotalHttpRequestThreshold should be disabled if alertingPlatform is Sensu" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withTotalHttpRequestsCountThreshold(60, AlertingPlatform.Sensu)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.totalHttpRequestThreshold shouldBe None
+    }
+
+    "TotalHttpRequestThreshold should be enabled by default in integration" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withTotalHttpRequestsCountThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
+    }
+
+    "TotalHttpRequestThreshold should be disabled by default in production" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withTotalHttpRequestsCountThreshold(60)
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+
+      output.totalHttpRequestThreshold shouldBe None
+    }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilderSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.alertconfig.builder
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.alertconfig.builder.yaml.{YamlAverageCPUThresholdAlert, YamlBuilder, YamlContainerKillThresholdAlert}
+import uk.gov.hmrc.alertconfig.builder.yaml.{YamlAverageCPUThresholdAlert, YamlBuilder, YamlContainerKillThresholdAlert, YamlExceptionThresholdAlert, YamlHttp5xxPercentThresholdAlert}
 
 class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
@@ -61,6 +61,86 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
       val output = YamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.averageCPUThreshold shouldBe Some(YamlAverageCPUThresholdAlert(threshold))
+    }
+
+    "ErrorsLoggedThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.errorsLoggedThreshold shouldBe None
+    }
+
+    "ExceptionThreshold should be 2 by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.exceptionThreshold shouldBe Some(YamlExceptionThresholdAlert(2, "critical"))
+    }
+
+    "Http5xxPercentThreshold should be 100% by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(100.0, "critical"))
+    }
+
+    "Http5xxThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.http5xxThreshold shouldBe None
+    }
+
+    "HttpStatusPercentThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpStatusPercentThresholds shouldBe None
+    }
+
+    "HttpStatusThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpStatusThresholds shouldBe None
+    }
+
+    "HttpTrafficThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpTrafficThresholds shouldBe None
+    }
+
+    "LogMessageThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.logMessageThresholds shouldBe None
+    }
+
+    "MetricsThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.metricsThresholds shouldBe None
+    }
+
+    "TotalHttpRequestThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.totalHttpRequestThreshold shouldBe None
     }
   }
 }


### PR DESCRIPTION
What did we do?
--

1. Migrated all alerts in integration to Grafana

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4323

Evidence of work
--

1. Added tests, all tests passing
2. Tested locally with alert-config

Next Steps
--

1. Update alert-config to do the actual migration