### PR TITLE
TEL-4343 add management environment to migration (even though we don't use it for standard alerts)

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -126,6 +126,21 @@ object GrafanaMigration {
       AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,
       AlertType.MetricsThreshold -> AlertingPlatform.Sensu,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Sensu
+    ),
+
+    Environment.Management -> Map(
+      AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
     )
   )
     def isGrafanaEnabled(alertingPlatform: AlertingPlatform, currentEnvironment: Environment, alertType: AlertType): Boolean = {


### PR DESCRIPTION
What did we do?
--

1. Add management environment to migration "spreadsheet" (even though we don't use it for standard alerts). The absence of this environment is causing alert-config deploy job to fail. Microservice alerts cannot be created in management as we don't have any alert-config so this is a no-op

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4343

Evidence of work
--

1. Built library from branch, updated version in alert-config and deploy to management from branch, which succeeded:
<img width="1189" alt="image" src="https://github.com/hmrc/alert-config-builder/assets/18111914/3d2e2bf7-2776-4dbf-92e6-50501341ecf0">

Next Steps
--

1. Update alert-config to use the new release of alert-config-builder (which will automatically be created by jenkins after this PR is merged)

Risks
--

1. Adding management to "the spreadsheet" could potentially confuse future engineers into thinking management is part of the migration of standard alerts
