### PR TITLE
TEL-4349 migrate users to Grafana alerting in production: TotalHttpRequestThreshold

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-java adoptopenjdk-11.0.15+10
+java adoptopenjdk-11.0.21+9
 sbt 1.9.7
 scala 2.13.12

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -125,7 +125,7 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
       AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,
       AlertType.MetricsThreshold -> AlertingPlatform.Sensu,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Sensu
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
     ),
 
     Environment.Management -> Map(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlBuilder.scala
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import uk.gov.hmrc.alertconfig.builder.GrafanaMigration.isGrafanaEnabled
-import uk.gov.hmrc.alertconfig.builder.{AlertConfig, AlertConfigBuilder, AlertType, AlertingPlatform, AverageCPUThreshold, ContainerKillThreshold, Environment, ErrorsLoggedThreshold, ExceptionThreshold, Http5xxPercentThreshold, Http5xxThreshold, HttpStatusPercentThreshold, HttpStatusThreshold, HttpTrafficThreshold, LogMessageThreshold, Logger, MetricsThreshold, TotalHttpRequestThreshold}
+import uk.gov.hmrc.alertconfig.builder.{AlertConfig, AlertConfigBuilder, AlertType, AverageCPUThreshold, ContainerKillThreshold, Environment, ErrorsLoggedThreshold, ExceptionThreshold, Http5xxPercentThreshold, Http5xxThreshold, HttpStatusPercentThreshold, HttpStatusThreshold, HttpTrafficThreshold, LogMessageThreshold, Logger, MetricsThreshold, TotalHttpRequestThreshold}
 
 import java.io.File
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -792,7 +792,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .asJsObject
       .fields
 
-    serviceConfig("total-http-request-threshold") shouldBe JsNumber(500)
+    serviceConfig("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
   }
 
   "disable http 5xx threshold in Sensu when alerting platform is Grafana" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -783,9 +783,9 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     serviceConfig("containerKillThreshold") shouldBe JsNumber(Int.MaxValue)
   }
 
-  "configure total http request count threshold with given threshold" in {
+  "disable http request count threshold with given threshold when alerting platform is Grafana" in {
     val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
-      .withTotalHttpRequestsCountThreshold(500)
+      .withTotalHttpRequestsCountThreshold(500, AlertingPlatform.Grafana)
       .build
       .get
       .parseJson

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -686,7 +686,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val requestThreshold = 35
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
-        .withTotalHttpRequestsCountThreshold(requestThreshold)
+        .withTotalHttpRequestsCountThreshold(requestThreshold, AlertingPlatform.Grafana)
 
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
       val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -695,8 +695,8 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config: Map[String, JsValue] = configs(0)
       val service2Config: Map[String, JsValue] = configs(1)
 
-      service1Config("total-http-request-threshold") shouldBe JsNumber(requestThreshold)
-      service2Config("total-http-request-threshold") shouldBe JsNumber(requestThreshold)
+      service1Config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
+      service2Config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
     }
 
     "return TeamAlertConfigBuilder with disabled totalHttpRequestThreshold when alerting platform is Grafana" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -453,13 +453,13 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
     }
 
-    "TotalHttpRequestThreshold should be disabled by default in production" in {
+    "TotalHttpRequestThreshold should be enabled by default in production" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60)
 
       val output = YamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.totalHttpRequestThreshold shouldBe None
+      output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
     }
   }
 }


### PR DESCRIPTION
References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4349

Evidence of work
--

n/a

Next Steps
--

1. Update alert-config to use new version of alert-config-builder

Risks
--

1. "To check this has worked effectively, find a service which has this alert configured and validate that it appears in https://grafana-alerting.mdtp-production.telemetry.tax.service.gov.uk/alerting/list and does not appear in the ElasticSearch PagerDuty mappings (instructions here: https://github.com/hmrc/telemetry/blob/main/snippets/elasticsearch.md#fetch-for-a-given-service)." it's not yet clear to me what this is all about
