### PR TITLE
TEL-4363 Integrations yaml

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,6 +3,5 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"      % "sbt-auto-build" % "3.20.0")
-addSbtPlugin("org.scoverage"    % "sbt-scoverage"  % "1.6.1")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"   % "2.5.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"    % "0.6.4")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Integrations.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Integrations.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.alertconfig.builder
+package uk.gov.hmrc.alertconfig.builder.yaml
 
-trait AlertConfig {
-  def alertConfig: Seq[AlertConfigBuilder]
-
-  def environmentConfig: Seq[EnvironmentAlertBuilder] = alertConfig.flatMap(_.handlers).map(EnvironmentAlertBuilder(_))
-
-  implicit def teamAlertConfigToAlertConfigs(config: TeamAlertConfigBuilder): Seq[AlertConfigBuilder] = config.build
-}
+case class Integration(name: String, severitiesEnabled: SeveritiesEnabled)
+case class SeveritiesEnabled(warning: Boolean, critical: Boolean)
+case class Integrations(integrations: Seq[Integration])

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.yaml
+
+import uk.gov.hmrc.alertconfig.builder.yaml.YamlWriter.mapper
+import uk.gov.hmrc.alertconfig.builder.{Environment, EnvironmentAlertBuilder, Logger, Severity}
+
+import java.io.File
+import scala.collection.immutable.Seq
+
+object IntegrationsYamlBuilder {
+
+  val logger = new Logger()
+
+  def generate(environmentAlertBuilders: Seq[EnvironmentAlertBuilder], currentEnvironment: Environment, saveLocation: File): Unit = {
+    logger.debug(s"Generating integrations YAML for $currentEnvironment")
+    val enabledIntegrations = environmentAlertBuilders.flatMap { builder =>
+      val enabledEnvironments = builder.enabledEnvironments
+      Option.when(enabledEnvironments.contains(currentEnvironment)) {
+        val enabledSeverities = enabledEnvironments(currentEnvironment)
+        Integration(
+          name = builder.handlerName,
+          SeveritiesEnabled(
+            warning = enabledSeverities.contains(Severity.Warning),
+            critical = enabledSeverities.contains(Severity.Critical)
+          )
+        )
+      }
+    }.distinct
+
+    mapper.writeValue(saveLocation, Integrations(enabledIntegrations))
+
+    logger.debug(s"Done generating integrations YAML for $currentEnvironment")
+  }
+
+}

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlWriter.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.yaml
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+object YamlWriter {
+
+  val mapper: ObjectMapper = new ObjectMapper(
+    new YAMLFactory()
+      .disable(Feature.WRITE_DOC_START_MARKER)
+      .enable(Feature.INDENT_ARRAYS_WITH_INDICATOR)
+  )
+    .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+    .registerModule(DefaultScalaModule)
+
+}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.alertconfig.builder
+package uk.gov.hmrc.alertconfig.builder.yaml
 
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.alertconfig.builder.yaml.{YamlAverageCPUThresholdAlert, YamlBuilder, YamlContainerKillThresholdAlert, YamlExceptionThresholdAlert, YamlHttp5xxPercentThresholdAlert}
+import uk.gov.hmrc.alertconfig.builder.{AlertConfigBuilder, AlertingPlatform, Environment}
 
-class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
+class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     System.setProperty("app-config-path", "src/test/resources/app-config")
@@ -30,7 +30,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
 
   "convert(Seq[AlertConfig])" should {
     "when supplied an empty sequence it should return an empty list" in {
-      YamlBuilder.convert(Seq(), Environment.Qa) shouldBe List()
+      AlertsYamlBuilder.convert(Seq(), Environment.Qa) shouldBe List()
     }
   }
 
@@ -40,7 +40,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withContainerKillThreshold(threshold, AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.containerKillThreshold shouldBe Some(YamlContainerKillThresholdAlert(threshold))
     }
@@ -48,7 +48,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "averageCPUThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.averageCPUThreshold shouldBe None
     }
@@ -58,7 +58,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withAverageCPUThreshold(threshold)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.averageCPUThreshold shouldBe Some(YamlAverageCPUThresholdAlert(threshold))
     }
@@ -66,7 +66,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "ErrorsLoggedThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.errorsLoggedThreshold shouldBe None
     }
@@ -74,7 +74,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "ExceptionThreshold should be 2 by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.exceptionThreshold shouldBe Some(YamlExceptionThresholdAlert(2, "critical"))
     }
@@ -82,7 +82,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "Http5xxPercentThreshold should be 100% by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(100.0, "critical"))
     }
@@ -90,7 +90,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "Http5xxThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.http5xxThreshold shouldBe None
     }
@@ -98,7 +98,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "HttpStatusPercentThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpStatusPercentThresholds shouldBe None
     }
@@ -106,7 +106,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "HttpStatusThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpStatusThresholds shouldBe None
     }
@@ -114,7 +114,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "HttpTrafficThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpTrafficThresholds shouldBe None
     }
@@ -122,7 +122,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "LogMessageThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.logMessageThresholds shouldBe None
     }
@@ -130,7 +130,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "MetricsThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.metricsThresholds shouldBe None
     }
@@ -138,7 +138,7 @@ class YamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach 
     "TotalHttpRequestThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.totalHttpRequestThreshold shouldBe None
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.yaml
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+import uk.gov.hmrc.alertconfig.builder.{Environment, EnvironmentAlertBuilder, Severity}
+
+import java.io.{File, FileInputStream}
+import java.nio.file.Files
+import scala.io.Source
+
+class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    val foobat = "a"
+  }
+
+  override def beforeEach(): Unit = {
+    System.setProperty("app-config-path", "src/test/resources/app-config")
+    System.setProperty("zone-mapping-path", "src/test/resources/zone-to-service-domain-mapping.yml")
+  }
+
+  "generate" should {
+    "create a correctly defined YAML file containing integrations and severities for that env only" in {
+      val tmpDir = Files.createTempDirectory("integrations-test")
+      val testFile = new File(s"$tmpDir/integrations.yaml")
+      val currentEnvironment = Environment.Production
+
+      val environmentAlertBuilders: Seq[EnvironmentAlertBuilder] = Seq(
+        EnvironmentAlertBuilder("team-telemetry-both").inProduction(Set(Severity.Warning, Severity.Critical)),
+        EnvironmentAlertBuilder("team-telemetry-warning-only").inProduction(Set(Severity.Warning)),
+        EnvironmentAlertBuilder("team-telemetry-critical-only").inProduction(Set(Severity.Critical)),
+        // This one should not appear in the output YAML
+        EnvironmentAlertBuilder("team-telemetry-non-prod-one").disableProduction().inIntegration(Set(Severity.Warning, Severity.Critical))
+      )
+      IntegrationsYamlBuilder.generate(environmentAlertBuilders, currentEnvironment, testFile)
+
+      val yamlFromDisk = Source.fromFile(testFile).getLines().mkString("\n")
+
+      yamlFromDisk shouldBe
+        """integrations:
+          |  - name: "team-telemetry-both"
+          |    severitiesEnabled:
+          |      warning: true
+          |      critical: true
+          |  - name: "team-telemetry-warning-only"
+          |    severitiesEnabled:
+          |      warning: true
+          |      critical: false
+          |  - name: "team-telemetry-critical-only"
+          |    severitiesEnabled:
+          |      warning: false
+          |      critical: true"""
+          .stripMargin
+
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -34,7 +34,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withAverageCPUThreshold(60, AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.averageCPUThreshold shouldBe Some(YamlAverageCPUThresholdAlert(60))
     }
@@ -43,7 +43,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withAverageCPUThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.averageCPUThreshold shouldBe Some(YamlAverageCPUThresholdAlert(60))
     }
@@ -52,7 +52,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withAverageCPUThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.averageCPUThreshold shouldBe None
     }
@@ -61,7 +61,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withAverageCPUThreshold(60, AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.averageCPUThreshold shouldBe None
     }
@@ -70,7 +70,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withContainerKillThreshold(60, AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.containerKillThreshold shouldBe Some(YamlContainerKillThresholdAlert(60))
     }
@@ -79,7 +79,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withContainerKillThreshold(60, AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.containerKillThreshold shouldBe None
     }
@@ -88,7 +88,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withContainerKillThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.containerKillThreshold shouldBe Some(YamlContainerKillThresholdAlert(60))
     }
@@ -97,7 +97,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withContainerKillThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.containerKillThreshold shouldBe None
     }
@@ -106,7 +106,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60, AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.errorsLoggedThreshold shouldBe Some(YamlErrorsLoggedThresholdAlert(60))
     }
@@ -115,7 +115,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60, AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.errorsLoggedThreshold shouldBe None
     }
@@ -124,7 +124,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.errorsLoggedThreshold shouldBe Some(YamlErrorsLoggedThresholdAlert(60))
     }
@@ -133,7 +133,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.errorsLoggedThreshold shouldBe None
     }
@@ -142,7 +142,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withExceptionThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.exceptionThreshold shouldBe Some(YamlExceptionThresholdAlert(60, "critical"))
     }
@@ -151,7 +151,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withExceptionThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.exceptionThreshold shouldBe None
     }
@@ -160,7 +160,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withExceptionThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.exceptionThreshold shouldBe Some(YamlExceptionThresholdAlert(60, "critical"))
     }
@@ -169,7 +169,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withExceptionThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.exceptionThreshold shouldBe None
     }
@@ -178,7 +178,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, "critical"))
     }
@@ -187,7 +187,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.http5xxPercentThreshold shouldBe None
     }
@@ -196,7 +196,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, "critical"))
     }
@@ -205,7 +205,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.http5xxPercentThreshold shouldBe None
     }
@@ -214,7 +214,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.http5xxThreshold shouldBe Some(YamlHttp5xxThresholdAlert(60, "critical"))
     }
@@ -223,7 +223,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.http5xxThreshold shouldBe None
     }
@@ -232,7 +232,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.http5xxThreshold shouldBe Some(YamlHttp5xxThresholdAlert(60, "critical"))
     }
@@ -241,7 +241,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.http5xxThreshold shouldBe None
     }
@@ -250,7 +250,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Grafana))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.httpStatusPercentThresholds shouldBe Some(List(YamlHttpStatusPercentThresholdAlert(60, "ALL_METHODS", 500, "critical")))
     }
@@ -259,7 +259,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Sensu))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpStatusPercentThresholds shouldBe None
     }
@@ -268,7 +268,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpStatusPercentThresholds shouldBe Some(List(YamlHttpStatusPercentThresholdAlert(60, "ALL_METHODS", 500, "critical")))
     }
@@ -277,7 +277,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.httpStatusPercentThresholds shouldBe None
     }
@@ -286,7 +286,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Grafana))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.httpStatusThresholds shouldBe Some(List(YamlHttpStatusThresholdAlert(60, "ALL_METHODS", 500, "critical")))
     }
@@ -295,7 +295,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Sensu))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpStatusThresholds shouldBe None
     }
@@ -304,7 +304,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpStatusThresholds shouldBe Some(List(YamlHttpStatusThresholdAlert(60, "ALL_METHODS", 500, "critical")))
     }
@@ -313,7 +313,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.httpStatusThresholds shouldBe None
     }
@@ -322,7 +322,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60), alertingPlatform = AlertingPlatform.Grafana))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.httpTrafficThresholds shouldBe Some(List(YamlHttpTrafficThresholdAlert(60, 5, "critical")))
     }
@@ -331,7 +331,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60), alertingPlatform = AlertingPlatform.Sensu))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpTrafficThresholds shouldBe None
     }
@@ -340,7 +340,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60)))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.httpTrafficThresholds shouldBe Some(List(YamlHttpTrafficThresholdAlert(60, 5, "critical")))
     }
@@ -349,7 +349,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60)))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.httpTrafficThresholds shouldBe None
     }
@@ -358,7 +358,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60, alertingPlatform = AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(60, false, "LOG_MESSAGE", "critical")))
     }
@@ -367,7 +367,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60, alertingPlatform = AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.logMessageThresholds shouldBe None
     }
@@ -376,7 +376,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(60, false, "LOG_MESSAGE", "critical")))
     }
@@ -385,7 +385,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.logMessageThresholds shouldBe None
     }
@@ -394,7 +394,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1), alertingPlatform = AlertingPlatform.Grafana))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(1, "metric", "a.b.c.d", "critical", false)))
     }
@@ -403,7 +403,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1), alertingPlatform = AlertingPlatform.Sensu))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.metricsThresholds shouldBe None
     }
@@ -412,7 +412,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1)))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(1, "metric", "a.b.c.d", "critical", false)))
     }
@@ -421,7 +421,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1)))
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.metricsThresholds shouldBe None
     }
@@ -430,7 +430,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60, AlertingPlatform.Grafana)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
     }
@@ -439,7 +439,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60, AlertingPlatform.Sensu)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.totalHttpRequestThreshold shouldBe None
     }
@@ -448,7 +448,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Integration)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
       output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
     }
@@ -457,7 +457,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60)
 
-      val output = YamlBuilder.convertAlerts(config, Environment.Production)
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
       output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
     }


### PR DESCRIPTION
Added functionality to create a YAML file that contains all the PagerDuty integrations active for that environment along with what severities are enabled for that handler in that environment

<details>

<summary>Example output file (click to expand)</summary>

```yaml
integrations:
  - name: "labs-team-telemetry"
    severitiesEnabled:
      warning: true
      critical: true
  - name: "build-and-deploy-warnings"
    severitiesEnabled:
      warning: true
      critical: true
  - name: "cip-asad-nonprod"
    severitiesEnabled:
      warning: false
      critical: true
  - name: "cip-attrep-nonprod"
    severitiesEnabled:
      warning: true
      critical: true
  - name: "cip-cdp-nonprod"
    severitiesEnabled:
      warning: false
      critical: true
  - name: "cip-cit-nonprod"
    severitiesEnabled:
      warning: false
      critical: true
  - name: "cip-dbd-nonprod"
    severitiesEnabled:
      warning: false
      critical: true
  - name: "cip-cie-nonprod"
    severitiesEnabled:
      warning: false
      critical: true
  - name: "cip-searchui-nonprod"
    severitiesEnabled:
      warning: false
      critical: true
  - name: "team-webops"
    severitiesEnabled:
      warning: true
      critical: true
  - name: "infrastructure"
    severitiesEnabled:
      warning: true
      critical: true
  - name: "platsec"
    severitiesEnabled:
      warning: true
      critical: true
  - name: "team-telemetry"
    severitiesEnabled:
      warning: true
      critical: true
  - name: "team-telemetry-heartbeat"
    severitiesEnabled:
      warning: true
      critical: true
```

</details>



Co-authored-by: Rob White <Crumplepang@users.noreply.github.com>
Co-authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>