### PR TITLE
TEL-4331 Adds support for Http90PercentileResponseTimeThreshold as a Grafana alert

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -33,6 +33,7 @@ object AlertType {
   object LogMessageThreshold extends AlertType
   object MetricsThreshold extends AlertType
   object TotalHttpRequestThreshold extends AlertType
+  object Http90PercentileResponseTimeThreshold extends AlertType
 }
 
 object GrafanaMigration {
@@ -50,7 +51,8 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
 
     Environment.Development -> Map(
@@ -65,7 +67,9 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
+
     ),
 
     Environment.Qa -> Map(
@@ -80,7 +84,8 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
     ),
 
     Environment.Staging -> Map(
@@ -95,7 +100,8 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
     ),
 
     Environment.ExternalTest -> Map(
@@ -110,7 +116,8 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
     ),
 
     Environment.Production -> Map(
@@ -125,7 +132,8 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
       AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,
       AlertType.MetricsThreshold -> AlertingPlatform.Sensu,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
     ),
 
     Environment.Management -> Map(
@@ -140,7 +148,8 @@ object GrafanaMigration {
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana
+      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
     )
   )
     def isGrafanaEnabled(alertingPlatform: AlertingPlatform, currentEnvironment: Environment, alertType: AlertType): Boolean = {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http90PercentileThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http90PercentileThreshold.scala
@@ -21,7 +21,8 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 case class Http90PercentileResponseTimeThreshold(
     warning: Option[Int],
     critical: Option[Int],
-    timePeriod: Int = 15
+    timePeriod: Int = 15,
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object Http90PercentileResponseTimeThresholdProtocol {
@@ -29,7 +30,7 @@ object Http90PercentileResponseTimeThresholdProtocol {
   import DefaultJsonProtocol._
 
   implicit val thresholdPercentileFormat: JsonFormat[Http90PercentileResponseTimeThreshold] = {
-    jsonFormat3(Http90PercentileResponseTimeThreshold)
+    jsonFormat4(Http90PercentileResponseTimeThreshold)
   }
 
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -219,4 +219,31 @@ object AlertsYamlBuilder {
     Option.when(converted.nonEmpty)(converted)
   }
 
+
+  def convertlHttp90PercentileResponseTimeThreshold(http90PercentileResponseTimeThreshold: Seq[Http90PercentileResponseTimeThreshold], currentEnvironment: Environment): Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = {
+    val converted = http90PercentileResponseTimeThreshold.flatMap { threshold =>
+      if (isGrafanaEnabled(threshold.alertingPlatform, currentEnvironment, AlertType.Http90PercentileResponseTimeThreshold)) {
+        Seq(
+          threshold.warning.map { warningCount =>
+            YamlHttp90PercentileResponseTimeThresholdAlert(
+              count = warningCount,
+              timePeriod = threshold.timePeriod,
+              severity = "warning"
+            )
+          },
+          threshold.critical.map { criticalCount =>
+            YamlHttp90PercentileResponseTimeThresholdAlert(
+              count = criticalCount,
+              timePeriod = threshold.timePeriod,
+              severity = "critical"
+            )
+          }
+        ).flatten
+      } else {
+        Seq.empty
+      }
+    }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -72,7 +72,8 @@ object AlertsYamlBuilder {
       httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds, currentEnvironment),
       logMessageThresholds = convertLogMessageThresholdAlerts(alertConfigBuilder.logMessageThresholds, currentEnvironment),
       totalHttpRequestThreshold = convertTotalHttpRequestThreshold(alertConfigBuilder.totalHttpRequestThreshold, currentEnvironment),
-      metricsThresholds = convertMetricsThreshold(alertConfigBuilder.metricsThresholds, currentEnvironment)
+      metricsThresholds = convertMetricsThreshold(alertConfigBuilder.metricsThresholds, currentEnvironment),
+      http90PercentileResponseTimeThreshold = convertHttp90PercentileResponseTimeThreshold(alertConfigBuilder.http90PercentileResponseTimeThresholds, currentEnvironment)
     )
   }
 
@@ -220,7 +221,7 @@ object AlertsYamlBuilder {
   }
 
 
-  def convertlHttp90PercentileResponseTimeThreshold(http90PercentileResponseTimeThreshold: Seq[Http90PercentileResponseTimeThreshold], currentEnvironment: Environment): Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = {
+  def convertHttp90PercentileResponseTimeThreshold(http90PercentileResponseTimeThreshold: Seq[Http90PercentileResponseTimeThreshold], currentEnvironment: Environment): Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = {
     val converted = http90PercentileResponseTimeThreshold.flatMap { threshold =>
       if (isGrafanaEnabled(threshold.alertingPlatform, currentEnvironment, AlertType.Http90PercentileResponseTimeThreshold)) {
         Seq(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
@@ -32,7 +32,8 @@ case class Alerts(
                    httpStatusThresholds: Option[Seq[YamlHttpStatusThresholdAlert]] = None,
                    httpTrafficThresholds: Option[Seq[YamlHttpTrafficThresholdAlert]] = None,
                    totalHttpRequestThreshold: Option[YamlTotalHttpRequestThresholdAlert] = None,
-                   metricsThresholds: Option[Seq[YamlMetricsThresholdAlert]] = None
+                   metricsThresholds: Option[Seq[YamlMetricsThresholdAlert]] = None,
+                   http90PercentileResponseTimeThreshold: Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = None,
                  )
 
 case class PagerDuty(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
@@ -81,3 +81,9 @@ case class YamlMetricsThresholdAlert(
 case class YamlTotalHttpRequestThresholdAlert(
                                                count: Int
                                              )
+
+case class YamlHttp90PercentileResponseTimeThresholdAlert(
+                                      timePeriod: Int,
+                                      count: Int,
+                                      severity: String
+                                   )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -525,7 +525,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      val expected = JsObject("warning" -> JsNumber(10), "critical" -> JsNumber(5), "timePeriod" -> JsNumber(10))
+      val expected = JsObject("alertingPlatform" -> JsString("Default"), "warning" -> JsNumber(10), "critical" -> JsNumber(5), "timePeriod" -> JsNumber(10))
 
       service1Config("http90PercentileResponseTimeThresholds") shouldBe expected
       service2Config("http90PercentileResponseTimeThresholds") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -531,6 +531,25 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       service2Config("http90PercentileResponseTimeThresholds") shouldBe expected
     }
 
+    "return TeamAlertConfigBuilder with correct http90PercentileResponseTimeThreshold with alerting platform set to Grafana" in {
+      val threshold = Http90PercentileResponseTimeThreshold(Some(10), Some(5), timePeriod = 10, alertingPlatform = AlertingPlatform.Grafana)
+      val alertConfigBuilder = TeamAlertConfigBuilder
+        .teamAlerts(Seq("service1", "service2"))
+        .withHttp90PercentileResponseTimeThreshold(threshold)
+
+      alertConfigBuilder.services shouldBe Seq("service1", "service2")
+      val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
+
+      configs.size shouldBe 2
+      val service1Config = configs(0)
+      val service2Config = configs(1)
+
+      val expected = JsObject("alertingPlatform" -> JsString("Grafana"), "warning" -> JsNumber(10), "critical" -> JsNumber(5), "timePeriod" -> JsNumber(10))
+
+      service1Config("http90PercentileResponseTimeThresholds") shouldBe expected
+      service2Config("http90PercentileResponseTimeThresholds") shouldBe expected
+    }
+
     "throw an exception if http90PercentileResponseTimeThreshold timePeriod is not valid" in {
       an[Exception] should be thrownBy
         TeamAlertConfigBuilder


### PR DESCRIPTION
What did we do?
--

1. Added support for `Http90PercentileResponseTimeThreshold` as a Grafana alert
2. Defaulted it to Grafana in mdtp-integration only

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4331

Evidence of work
--

1. Autoamted tests
2. Configured `alert-config` locally to use this branch; it outputs the following for alert-simulator in integration:
```
      http90PercentileResponseTimeThreshold:
        - timePeriod: 14
          count: 1000
          severity: "warning"
        - timePeriod: 14
          count: 2000
          severity: "critical"
```

Next Steps
--

1. Update alert-config
2. 2. Implement in telemetry-grafana-alert-config
3. If this is all OK, enable `Http90PercentileResponseTimeThreshold` for other envs in `src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala`


Risks
--

1. good chance I've bungled something

Collaboration
--

Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>
