### PR TITLE
TEL-4363 Generate integrations YAML as array

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Integrations.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Integrations.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.alertconfig.builder.yaml
 
-case class Integration(name: String, severitiesEnabled: SeveritiesEnabled)
-case class SeveritiesEnabled(warning: Boolean, critical: Boolean)
+import uk.gov.hmrc.alertconfig.builder.Severity
+
+case class Integration(name: String, severitiesEnabled: Seq[String])
 case class Integrations(integrations: Seq[Integration])

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.alertconfig.builder.yaml
 
 import uk.gov.hmrc.alertconfig.builder.yaml.YamlWriter.mapper
 import uk.gov.hmrc.alertconfig.builder.{Environment, EnvironmentAlertBuilder, Logger, Severity}
+import uk.gov.hmrc.alertconfig.builder.Severity._
 
 import java.io.File
 import scala.collection.immutable.Seq
@@ -34,10 +35,7 @@ object IntegrationsYamlBuilder {
         val enabledSeverities = enabledEnvironments(currentEnvironment)
         Integration(
           name = builder.handlerName,
-          SeveritiesEnabled(
-            warning = enabledSeverities.contains(Severity.Warning),
-            critical = enabledSeverities.contains(Severity.Critical)
-          )
+          severitiesEnabled = enabledSeverities.filter(Seq(Critical, Warning).contains(_)).map(_.toString).toSeq
         )
       }
     }.distinct

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlWriter.scala
@@ -27,6 +27,7 @@ object YamlWriter {
   val mapper: ObjectMapper = new ObjectMapper(
     new YAMLFactory()
       .disable(Feature.WRITE_DOC_START_MARKER)
+      .enable(Feature.MINIMIZE_QUOTES)
       .enable(Feature.INDENT_ARRAYS_WITH_INDICATOR)
   )
     .setSerializationInclusion(JsonInclude.Include.NON_ABSENT)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
@@ -43,6 +43,7 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
     "create a correctly defined YAML file containing integrations and severities for that env only" in {
       val tmpDir = Files.createTempDirectory("integrations-test")
       val testFile = new File(s"$tmpDir/integrations.yaml")
+      println(Console.RED + s"testFile = ${testFile}" + Console.RESET)
       val currentEnvironment = Environment.Production
 
       val environmentAlertBuilders: Seq[EnvironmentAlertBuilder] = Seq(
@@ -60,16 +61,14 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         """integrations:
           |  - name: "team-telemetry-both"
           |    severitiesEnabled:
-          |      warning: true
-          |      critical: true
+          |      - "warning"
+          |      - "critical"
           |  - name: "team-telemetry-warning-only"
           |    severitiesEnabled:
-          |      warning: true
-          |      critical: false
+          |      - "warning"
           |  - name: "team-telemetry-critical-only"
           |    severitiesEnabled:
-          |      warning: false
-          |      critical: true"""
+          |      - "critical""""
           .stripMargin
 
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
@@ -16,23 +16,16 @@
 
 package uk.gov.hmrc.alertconfig.builder.yaml
 
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.constructor.Constructor
 import uk.gov.hmrc.alertconfig.builder.{Environment, EnvironmentAlertBuilder, Severity}
 
-import java.io.{File, FileInputStream}
+import java.io.File
 import java.nio.file.Files
 import scala.io.Source
 
-class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
-
-  override protected def beforeAll(): Unit = {
-    super.beforeAll()
-    val foobat = "a"
-  }
+class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     System.setProperty("app-config-path", "src/test/resources/app-config")
@@ -43,7 +36,6 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
     "create a correctly defined YAML file containing integrations and severities for that env only" in {
       val tmpDir = Files.createTempDirectory("integrations-test")
       val testFile = new File(s"$tmpDir/integrations.yaml")
-      println(Console.RED + s"testFile = ${testFile}" + Console.RESET)
       val currentEnvironment = Environment.Production
 
       val environmentAlertBuilders: Seq[EnvironmentAlertBuilder] = Seq(
@@ -59,16 +51,16 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
 
       yamlFromDisk shouldBe
         """integrations:
-          |  - name: "team-telemetry-both"
+          |  - name: team-telemetry-both
           |    severitiesEnabled:
-          |      - "warning"
-          |      - "critical"
-          |  - name: "team-telemetry-warning-only"
+          |      - warning
+          |      - critical
+          |  - name: team-telemetry-warning-only
           |    severitiesEnabled:
-          |      - "warning"
-          |  - name: "team-telemetry-critical-only"
+          |      - warning
+          |  - name: team-telemetry-critical-only
           |    severitiesEnabled:
-          |      - "critical""""
+          |      - critical"""
           .stripMargin
 
     }


### PR DESCRIPTION
Generate YAML severities as an array to make processing easier in `telemetry-grafana-alert-config`

```yaml
integrations:
  - name: agent-services
    severitiesEnabled:
      - warning
      - critical
  - name: alcohol-duty-reform
    severitiesEnabled:
      - warning
      - critical
```

Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>