### PR TITLE
TEL-4399 Adds info as valid status for AlertConfig alert

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.alertconfig.builder
 sealed trait AlertSeverity
 
 object AlertSeverity {
+  object Info  extends AlertSeverity { override def toString: String = "info"  }
   object Warning  extends AlertSeverity { override def toString: String = "warning"  }
   object Critical extends AlertSeverity { override def toString: String = "critical" }
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.alertconfig.builder
 sealed trait AlertSeverity
 
 object AlertSeverity {
-  object Info  extends AlertSeverity { override def toString: String = "info"  }
+  object Info     extends AlertSeverity { override def toString: String = "info"  }
   object Warning  extends AlertSeverity { override def toString: String = "warning"  }
   object Critical extends AlertSeverity { override def toString: String = "critical" }
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -23,7 +23,7 @@ sealed trait Severity {
 }
 
 object Severity {
-  object Info       extends Severity
+  object Info     extends Severity
   object Ok       extends Severity
   object Warning  extends Severity
   object Critical extends Severity

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -76,12 +76,12 @@ object AllEnvironmentAlertConfigBuilder {
 case class EnvironmentAlertBuilder(
     handlerName: String,
     command: Option[JsValue] = None,
-    enabledEnvironments: Map[Environment, Set[Severity]] = Map((Environment.Production, Set(Severity.Ok, Severity.Info, Severity.Warning, Severity.Critical))),
+    enabledEnvironments: Map[Environment, Set[Severity]] = Map((Environment.Production, Set(Severity.Ok, Severity.Warning, Severity.Critical))),
     customEnvironmentNames: Map[Environment, String] = Map((Environment.Production, "aws_production")),
     handlerFilters: Map[Environment, JsValue] = Map((Environment.Production, JsString("occurrences")))
 ) {
 
-  private val defaultSeverities: Set[Severity] = Set(Severity.Ok, Severity.Info, Severity.Warning, Severity.Critical)
+  private val defaultSeverities: Set[Severity] = Set(Severity.Ok, Severity.Warning, Severity.Critical)
   private val defaultFilter: JsValue           = JsString("occurrences")
   private val defaultMgmtFilter: JsValue       = JsArray(JsString("occurrences"), JsString("kitchen_filter"), JsString("packer_filter"))
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -23,6 +23,7 @@ sealed trait Severity {
 }
 
 object Severity {
+  object Info       extends Severity
   object Ok       extends Severity
   object Warning  extends Severity
   object Critical extends Severity
@@ -75,12 +76,12 @@ object AllEnvironmentAlertConfigBuilder {
 case class EnvironmentAlertBuilder(
     handlerName: String,
     command: Option[JsValue] = None,
-    enabledEnvironments: Map[Environment, Set[Severity]] = Map((Environment.Production, Set(Severity.Ok, Severity.Warning, Severity.Critical))),
+    enabledEnvironments: Map[Environment, Set[Severity]] = Map((Environment.Production, Set(Severity.Ok, Severity.Info, Severity.Warning, Severity.Critical))),
     customEnvironmentNames: Map[Environment, String] = Map((Environment.Production, "aws_production")),
     handlerFilters: Map[Environment, JsValue] = Map((Environment.Production, JsString("occurrences")))
 ) {
 
-  private val defaultSeverities: Set[Severity] = Set(Severity.Ok, Severity.Warning, Severity.Critical)
+  private val defaultSeverities: Set[Severity] = Set(Severity.Ok, Severity.Info, Severity.Warning, Severity.Critical)
   private val defaultFilter: JsValue           = JsString("occurrences")
   private val defaultMgmtFilter: JsValue       = JsArray(JsString("occurrences"), JsString("kitchen_filter"), JsString("packer_filter"))
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Integrations.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Integrations.scala
@@ -16,7 +16,5 @@
 
 package uk.gov.hmrc.alertconfig.builder.yaml
 
-import uk.gov.hmrc.alertconfig.builder.Severity
-
 case class Integration(name: String, severitiesEnabled: Seq[String])
 case class Integrations(integrations: Seq[Integration])

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -35,7 +35,7 @@ object IntegrationsYamlBuilder {
         val enabledSeverities = enabledEnvironments(currentEnvironment)
         Integration(
           name = builder.handlerName,
-          severitiesEnabled = enabledSeverities.filter(Seq(Critical, Warning).contains(_)).map(_.toString).toSeq
+          severitiesEnabled = enabledSeverities.filter(Seq(Critical, Warning, Info).contains(_)).map(_.toString).toSeq
         )
       }
     }.distinct

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -27,7 +27,7 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
     JsObject(
       "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
       "type"       -> JsString("pipe"),
-      "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+      "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
       "filter"     -> JsString("occurrences")
     )
 
@@ -35,7 +35,7 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
     JsObject(
       "command"    -> JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team $service -e $environment"),
       "type"       -> JsString("pipe"),
-      "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+      "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
       "filter"     -> JsString("occurrences")
     )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -27,7 +27,7 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
     JsObject(
       "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
       "type"       -> JsString("pipe"),
-      "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+      "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
       "filter"     -> JsString("occurrences")
     )
 
@@ -35,7 +35,7 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
     JsObject(
       "command"    -> JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team $service -e $environment"),
       "type"       -> JsString("pipe"),
-      "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+      "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
       "filter"     -> JsString("occurrences")
     )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
@@ -30,7 +30,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team team-telemetry -e aws_production"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -41,7 +41,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -52,7 +52,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team infra -e aws_integration"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -66,7 +66,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/some-custom-ruby-handler.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -77,7 +77,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -88,7 +88,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team txm-infra -e txm_integration"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -99,7 +99,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -123,7 +123,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team infra -e aws_management"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
           "filters"    -> JsArray(JsString("occurrences"), JsString("kitchen_filter"), JsString("packer_filter"))
         )
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
@@ -30,7 +30,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team team-telemetry -e aws_production"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -41,7 +41,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -52,7 +52,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team infra -e aws_integration"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -66,7 +66,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/some-custom-ruby-handler.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -77,7 +77,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -88,7 +88,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team txm-infra -e txm_integration"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -99,20 +99,20 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filter"     -> JsString("occurrences")
         )
     }
 
     "create config with integration enabled with custom severities" in {
       EnvironmentAlertBuilder("team-telemetry")
-        .inIntegration(Set(Severity.Ok, Severity.Warning, Severity.Critical, Severity.Unknown))
+        .inIntegration(Set(Severity.Ok, Severity.Info, Severity.Warning, Severity.Critical, Severity.Unknown))
         .alertConfigFor(Environment.Integration) shouldBe
         "team-telemetry" ->
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team team-telemetry -e aws_integration"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical"), JsString("unknown")),
+          "severities" -> JsArray(JsString("info"), JsString("critical"), JsString("unknown"), JsString("warning"), JsString("ok")),
           "filter"     -> JsString("occurrences")
         )
     }
@@ -123,7 +123,7 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team infra -e aws_management"),
           "type"       -> JsString("pipe"),
-          "severities" -> JsArray(JsString("ok"), JsString("warning"), JsString("critical")),
+          "severities" -> JsArray(JsString("ok"), JsString("info"), JsString("warning"), JsString("critical")),
           "filters"    -> JsArray(JsString("occurrences"), JsString("kitchen_filter"), JsString("packer_filter"))
         )
     }


### PR DESCRIPTION
What did we do?
--

1. Added info as a valid status

The idea is that we can change the flip-flop metric so that it create an `info` alert instead of a critical one. This is semantically better - having big red scary alerts in Pagerduty is a problem on support.

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4399

Evidence of work
--

1. Automated tests

Next Steps
--

1. Update alert-config to support this for the `alert-simulator` to send `info` level alarms.

Risks
--

1. I might have misunderstood the new severity mechanism

Collaboration
--

Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>
Co-authored-by: Muhammed Ahmed <ma3574@users.noreply.github.com>
