### PR TITLE
TEL-4331 Sets Http90PercentileResponseTimeThreshold to grafana in low…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -68,8 +68,7 @@ object GrafanaMigration {
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
-
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
 
     Environment.Qa -> Map(
@@ -85,7 +84,7 @@ object GrafanaMigration {
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
 
     Environment.Staging -> Map(
@@ -101,7 +100,7 @@ object GrafanaMigration {
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
 
     Environment.ExternalTest -> Map(
@@ -149,7 +148,7 @@ object GrafanaMigration {
       AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
       AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
       AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
+      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     )
   )
     def isGrafanaEnabled(alertingPlatform: AlertingPlatform, currentEnvironment: Environment, alertType: AlertType): Boolean = {


### PR DESCRIPTION
…er envs

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4331

Evidence of work
--

1. This works fine in integration
![image](https://github.com/hmrc/alert-config-builder/assets/205245/a2d9f1cc-0484-40b8-a5ab-bf8f30495414)


Next Steps
--

n/a

Risks
--

1. Ticket doesn't specify when to put this live in prod

Collaboration
--

Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>
Co-authored by: Rob White <Crumplepang@users.noreply.github.com>
