### PR TITLE
TEL-4408 Enables info alert level everywhere

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -193,6 +193,9 @@ case class EnvironmentAlertBuilder(
 
   private def severitiesFor(environment: Environment) =
     JsArray(enabledEnvironments.getOrElse(environment, defaultSeverities)
+      // Temporary filter as part of TEL-4408 to ensure that info level
+      // notifications can't be enabled. They are only added to specific YAML
+      // files. Yes this is a hack, and when Sensu is gone, it can go too!
       .filter(s => !s.toString.equalsIgnoreCase("info"))
       .map(s => JsString(s.toString)).toVector)
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -40,7 +40,7 @@ object IntegrationsYamlBuilder {
         // 2. in YAML (for Grafana)
         //
         // If we turn it on in Sensu, the entirety of Sensu crashes HARD! see TEL-4404
-        if (builder.handlerName.equals("team-telemetry-heartbeat") && currentEnvironment.toString.equals("aws_integration")) {
+        if (builder.handlerName.equals("team-telemetry-heartbeat")) {
           Integration(
             name = builder.handlerName,
             severitiesEnabled = Seq(Critical, Warning, Info).map(_.toString)


### PR DESCRIPTION
References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4408

See https://github.com/hmrc/alert-config-builder/pull/95 for full details

Evidence of work
--

1. This worked just fine in integration
2. Integration stopped spamming #team-telemetry-tests

Next Steps
--

1. See if there's a way we can figure out how to set urgency to LOW

Risks
--

1.

Collaboration
--

Co-authored by: Rob White <Crumplepang@users.noreply.github.com>
Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>

