### PR TITLE
TEL-4397 Only create alert config for services that are deployed

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AppConfigValidator.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AppConfigValidator.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder
+
+import org.yaml.snakeyaml.Yaml
+
+import java.io.{File, FileInputStream, FileNotFoundException}
+import scala.util.{Failure, Success, Try}
+import scala.jdk.CollectionConverters._
+
+
+object AppConfigValidator {
+  val logger = new Logger()
+
+  def getAppConfigFileForService(serviceName: String, platformService: Boolean): Option[File] = {
+    val appConfigPath = System.getProperty("app-config-path", "../app-config")
+    val appConfigDirectory = new File(appConfigPath)
+    val appConfigFile = new File(appConfigDirectory, s"${serviceName}.yaml")
+
+    if (!appConfigDirectory.exists)
+      throw new FileNotFoundException(s"Could not find app-config repository: $appConfigPath")
+
+    appConfigFile match {
+      case file if !platformService && !file.exists =>
+        logger.info(s"No app-config file found for service: '${serviceName}'. File was expected at: '${file.getAbsolutePath}'")
+        None
+      case file if !platformService && getZone(serviceName, file).isEmpty =>
+        logger.warn(s"app-config file for service: '${serviceName}' does not contain 'zone' key.")
+        None
+      case file => Some(file)
+    }
+  }
+
+  def serviceDeployedInEnv(serviceName: String, platformService: Boolean): Boolean =
+    getAppConfigFileForService(serviceName, platformService) match {
+      case Some(file) => true
+      case None       => false
+    }
+
+  def getZone(serviceName:String, appConfigFile: File, platformService: Boolean = false): Option[String] =
+    if (platformService)
+      None
+    else {
+      def parseAppConfigFile: Try[java.util.Map[String, java.util.Map[String, String]]] =
+        Try(new Yaml().load(new FileInputStream(appConfigFile)).asInstanceOf[java.util.Map[String, java.util.Map[String, String]]])
+
+      parseAppConfigFile match {
+        case Failure(exception) =>
+          logger.warn(
+            s"app-config file ${appConfigFile} for service: '${serviceName}' is not valid YAML and could not be parsed. Parsing Exception: ${exception.getMessage}")
+          None
+        case Success(appConfig) =>
+          val versionObject = appConfig.asScala.toMap.view.mapValues(_.asScala.toMap)("0.0.0")
+          versionObject.get("zone")
+      }
+    }
+}

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.alertconfig.builder.yaml.YamlWriter.mapper
 import java.io.File
 
 object AlertsYamlBuilder {
-
+  import AppConfigValidator._
   val logger = new Logger()
 
   def run(alertConfigs: Seq[AlertConfig], environment: String): Unit = {
@@ -47,7 +47,7 @@ object AlertsYamlBuilder {
 
   def convert(alertConfigBuilder: AlertConfigBuilder, environmentDefinedHandlers: Set[String], currentEnvironment: Environment): Option[ServiceConfig] = {
     val enabledHandlers = alertConfigBuilder.handlers.toSet.intersect(environmentDefinedHandlers)
-    if (enabledHandlers.isEmpty) {
+    if (enabledHandlers.isEmpty || !serviceDeployedInEnv(alertConfigBuilder.serviceName, alertConfigBuilder.platformService)) {
       None
     } else {
       Some(

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -34,6 +34,17 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
     }
   }
 
+  "convert(AlertConfig, Environment)" should {
+    "filter out alerting configuration for services without an entry in app-config-env (meaning they are undeployed)" in {
+      val config = AlertConfigBuilder("service-without-app-config-entry", handlers = Seq("h1", "h2"))
+        .withContainerKillThreshold(10, AlertingPlatform.Grafana)
+
+      val res    = AlertsYamlBuilder.convert(alertConfigBuilder = config, environmentDefinedHandlers = Set("h1"), currentEnvironment = Environment.Production)
+
+      res shouldBe None
+    }
+  }
+
   "convertAlerts(alertConfigBuilder)" should {
     "containerKillThreshold should be set to defined threshold" in {
       val threshold = 56

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -360,7 +360,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(60, false, "LOG_MESSAGE", "critical")))
+      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(count = 60, lessThanMode = false, message = "LOG_MESSAGE", severity = "critical")))
     }
 
     "LogMessageThreshold should be disabled if alertingPlatform is Sensu" in {
@@ -378,7 +378,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
-      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(60, false, "LOG_MESSAGE", "critical")))
+      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(count = 60, lessThanMode = false, message = "LOG_MESSAGE", severity = "critical")))
     }
 
     "LogMessageThreshold should be disabled by default in production" in {
@@ -396,7 +396,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(1, "metric", "a.b.c.d", "critical", false)))
+      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(count = 1, name = "metric", query = "a.b.c.d", severity = "critical", invert = false)))
     }
 
     "MetricsThreshold should be disabled if alertingPlatform is Sensu" in {
@@ -414,7 +414,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
-      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(1, "metric", "a.b.c.d", "critical", false)))
+      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(count = 1, name = "metric", query = "a.b.c.d", severity = "critical", invert = false)))
     }
 
     "MetricsThreshold should be disabled by default in production" in {


### PR DESCRIPTION
What did we do?
--

- In order to ensure that we don't trigger alerts for services that aren't actually deployed (no data can cause false positives), there was some existing business logic which only created service-config if that service has an entry in app-config-$env. This ensured that the $service.json config file was not created for these undeployed services. 
- However, this logic only applied to alerts created in Sensu. This is because we generate YAML (which is used by Grafana-Alerting) based on the pre-filtered Scala objects in memory - not based on the created json files.
- This PR replicates that logic for the generation of Grafana-Alerting YAML.
- Note - rather than duplicate the exact same logic in two places, I moved the logic to a helper object. 

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4397

Evidence of work
--

1. Unit test added to ensure it filters out as expected.
2. Then, using a service which is not deployed in ET as an example:
3.  No results for 'trusts-enrolment-orchestrator' in services.yaml file on this branch against app-config-externaltest:
![image](https://github.com/hmrc/alert-config-builder/assets/60072280/a30d3bff-d406-4a51-8fdb-7f9456f89f25)
4. This same service was generated in the services.yaml file when it was ran on main branch, before my changes are applied: 
![image](https://github.com/hmrc/alert-config-builder/assets/60072280/9157d4d1-8577-45ca-ad45-fe20350281cf)


Next Steps
--

1. Merge change
2. Update alert-config dependency to use new build

Risks
--

1. The coverage provided by existing unit tests isn't enough to catch a regression that I've introduced...

