### PR TITLE
TEL-4397 Dont generate warning alerts if they will never be used due …

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -64,21 +64,18 @@ object AlertsYamlBuilder {
     }
   }
 
-  def removeUnusedAlerts(alertConfigBuilder: AlertConfigBuilder, handlerSeveritiesForEnv: Map[String, Set[Severity]]): AlertConfigBuilder =
-      if (alertConfigBuilder.handlers.exists(handler => handlerSeveritiesForEnv.getOrElse(handler, Set()).contains(Severity.Critical)) &&
-        !alertConfigBuilder.handlers.exists(handler => handlerSeveritiesForEnv.getOrElse(handler, Set()).contains(Severity.Warning))
-      ) {
+  def removeUnusedAlerts(alertConfigBuilder: AlertConfigBuilder, handlerSeveritiesForEnv: Map[String, Set[Severity]]): AlertConfigBuilder = {
+    val uniqueEnabledSeveritiesForServiceInEnv = handlerSeveritiesForEnv.values.flatten.toSet
+      if ( uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Critical) && !uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning)) {
         removeUnusedAlerts(alertConfigBuilder, AlertSeverity.Warning)
-      }
-      else if (
-        alertConfigBuilder.handlers.exists(handler => handlerSeveritiesForEnv.getOrElse(handler, Set()).contains(Severity.Warning)) &&
-          !alertConfigBuilder.handlers.exists(handler => handlerSeveritiesForEnv.getOrElse(handler, Set()).contains(Severity.Critical))
+      } else if (
+        uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning) && !uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Critical)
       ) {
         removeUnusedAlerts(alertConfigBuilder, AlertSeverity.Critical)
-      }
-      else {
+      } else {
         alertConfigBuilder
       }
+  }
 
   def removeUnusedAlerts(alertConfigBuilder: AlertConfigBuilder, severityToRemove: AlertSeverity): AlertConfigBuilder =
     alertConfigBuilder.copy(


### PR DESCRIPTION
…to environment config

What did we do?
--

1. It is currently possible for users to create alerts with Severity=Warn, but then to have the environment config set to receive critical alerts only. This would waste CPU for no good reason!
2. The inverse is also currently possible, i.e. Alerts created with a Critical severity but then the environment config is set to receive warning alerts only.
3. This PR prevents the creation of alerts that would never be received.

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4397

Evidence of work
--

1. Unit tests : - )
2. No diff in Staging between Services.yaml file before and after these changes
3. Diff in QA is shown below and has been validated against the alert-config repo to ensure changes are expected (Alerts to be deleted are highlighted bold):

```
- service: cds-reimbursement-claim
    alerts:
      containerKillThreshold:
        count: 1
      exceptionThreshold:
        count: 10
        severity: critical
      http5xxPercentThreshold:
        percentage: 100.0
        severity: critical
      httpStatusThresholds:
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 500
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 500
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 501
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 501
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 502
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 502
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 503
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 503
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 504
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 504
          severity: critical
    pagerduty:
      - integrationKeyName: cds-reimbursements-team
  - service: cds-reimbursement-claim-frontend
    alerts:
      containerKillThreshold:
        count: 1
      exceptionThreshold:
        count: 10
        severity: critical
      http5xxPercentThreshold:
        percentage: 100.0
        severity: critical
      httpStatusThresholds:
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 500
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 500
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 501
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 501
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 502
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 502
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 503
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 503
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 504
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 504
          severity: critical
    pagerduty:
      - integrationKeyName: cds-reimbursements-team
  - service: upload-customs-documents-frontend
    alerts:
      containerKillThreshold:
        count: 1
      exceptionThreshold:
        count: 10
        severity: critical
      http5xxPercentThreshold:
        percentage: 100.0
        severity: critical
      httpStatusThresholds:
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 500
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 500
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 501
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 501
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 502
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 502
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 503
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 503
          severity: critical
        **- count: 5
          httpMethod: ALL_METHODS
          httpStatus: 504
          severity: warning**
        - count: 100
          httpMethod: ALL_METHODS
          httpStatus: 504
          severity: critical
    pagerduty:
      - integrationKeyName: cds-reimbursements-team
```

Next Steps
--

1. Merge
4. Update alert config
5. Roll out alert-config

Risks
--

1. Low due to unit test, and the fact that QA and Staging have been ran locally to validate any diffs generated as a result of this change are expected. 

Collaboration
--

Co-authored-by: Gavin Davies [gavD@users.noreply.github.com](mailto:gavD@users.noreply.github.com)
Co-authored by: Rob White [Crumplepang@users.noreply.github.com](mailto:Crumplepang@users.noreply.github.com)
Co-authored-by: Muhammed Ahmed [ma3574@users.noreply.github.com](mailto:ma3574@users.noreply.github.com)