### PR TITLE
TEL-4389 Resolves warning for multiarg infix syntax

### DIFF
--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/ObjectScannerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/ObjectScannerSpec.scala
@@ -31,7 +31,7 @@ class ObjectScannerSpec extends AnyWordSpec with Matchers {
 
   "ClassScanner" should {
     "load all the singleton subtypes of a type in given package" in {
-      ObjectScanner.loadAll[SuperType](this.getClass.getPackage.getName) should contain only (A, B)
+      ObjectScanner.loadAll[SuperType](this.getClass.getPackage.getName) should contain.only (A, B)
     }
   }
 }


### PR DESCRIPTION
This is just a tweak to test the alert-config-builder pipeline will run Java 21 and NOT Java 11

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4389

Evidence of work
--

1. `sbt clean test` no longer emits a warning
2. Build is using right Java: ![image](https://github.com/hmrc/alert-config-builder/assets/205245/108d390c-0e4c-4851-bafe-0dcb13d9537c)

Risks
--

None

Collaboration
--

Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>

