### PR TITLE
TEL-4438 Generate yaml for HttpAbsolutePercentSplitThreshold alerts

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"      % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc"      % "sbt-auto-build" % "3.21.0")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"   % "2.5.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"    % "0.6.4")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -220,8 +220,7 @@ case class AlertConfigBuilder(
              |"total-http-request-threshold": $updatedTotalHttpRequestThreshold,
              |"log-message-thresholds" : ${logMessageThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).toJson.compactPrint},
              |"average-cpu-threshold" : $updatedAverageCPUThreshold,
-             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds)(
-              HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
+             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
              |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds)(
               HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
              |"absolute-percentage-split-downstream-hod-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamHodThresholds)(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -27,6 +27,7 @@ object AlertType {
   object ExceptionThreshold extends AlertType
   object Http5xxPercentThreshold extends AlertType
   object Http5xxThreshold extends AlertType
+  object HttpAbsolutePercentSplitThreshold extends AlertType
   object HttpStatusPercentThreshold extends AlertType
   object HttpStatusThreshold extends AlertType
   object HttpTrafficThreshold extends AlertType
@@ -46,6 +47,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
@@ -62,6 +64,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
@@ -78,6 +81,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
@@ -94,6 +98,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
@@ -110,6 +115,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
@@ -126,6 +132,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Sensu,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Sensu,
       AlertType.Http5xxThreshold -> AlertingPlatform.Sensu,
+      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
@@ -142,6 +149,7 @@ object GrafanaMigration {
       AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpAbsolutePercentSplitThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpAbsolutePercentSplitThreshold.scala
@@ -25,7 +25,8 @@ case class HttpAbsolutePercentSplitThreshold(
     hysteresis: Double = 1.0,
     excludeSpikes: Int = 0,
     errorFilter: String = "status:>498",
-    severity: AlertSeverity = AlertSeverity.Critical
+    severity: AlertSeverity = AlertSeverity.Critical,
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object HttpAbsolutePercentSplitThresholdProtocol {
@@ -33,7 +34,7 @@ object HttpAbsolutePercentSplitThresholdProtocol {
 
   implicit val thresholdFormat: JsonFormat[HttpAbsolutePercentSplitThreshold] = {
     implicit val asf: JsonFormat[AlertSeverity] = alertSeverityFormat
-    jsonFormat7(HttpAbsolutePercentSplitThreshold)
+    jsonFormat8(HttpAbsolutePercentSplitThreshold)
   }
 
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -101,6 +101,7 @@ object AlertsYamlBuilder {
       exceptionThreshold = convertExceptionThreshold(alertConfigBuilder.exceptionThreshold, currentEnvironment),
       http5xxPercentThreshold = convertHttp5xxPercentThresholds(alertConfigBuilder.http5xxPercentThreshold, currentEnvironment),
       http5xxThreshold = convertHttp5xxThreshold(alertConfigBuilder.http5xxThreshold, currentEnvironment),
+      httpAbsolutePercentSplitThreshold = convertHttpAbsolutePercentSplitThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitThresholds, currentEnvironment),
       httpStatusPercentThresholds = convertHttpStatusPercentThresholdAlerts(alertConfigBuilder.httpStatusPercentThresholds, currentEnvironment),
       httpStatusThresholds = convertHttpStatusThresholds(alertConfigBuilder.httpStatusThresholds, currentEnvironment),
       httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds, currentEnvironment),
@@ -154,6 +155,21 @@ object AlertsYamlBuilder {
         severity = http5xxThreshold.severity.toString
       )
     )
+  }
+  def convertHttpAbsolutePercentSplitThresholdAlert(httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = {
+    val converted =  httpAbsolutePercentSplitThresholds.withFilter(alert => isGrafanaEnabled(alert.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold) && alert.absoluteThreshold < Int.MaxValue).map {
+      threshold =>
+        YamlHttpAbsolutePercentSplitThresholdAlert(
+          percentThreshold  = threshold.percentThreshold,
+          crossover         = threshold.crossOver,
+          absoluteThreshold = threshold.absoluteThreshold,
+          hysteresis        = threshold.hysteresis,
+          excludeSpikes     = threshold.excludeSpikes,
+          errorFilter       = threshold.errorFilter,
+          severity          = threshold.severity.toString
+        )
+    }
+    Option.when(converted.nonEmpty)(converted)
   }
 
   def convertHttpStatusThresholds(httpStatusThresholds: Seq[HttpStatusThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpStatusThresholdAlert]] = {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
@@ -21,23 +21,24 @@ case class TopLevelConfig(services: Seq[ServiceConfig])
 case class ServiceConfig(service: String, alerts: Alerts, pagerduty: Seq[PagerDuty])
 
 case class Alerts(
-                   averageCPUThreshold: Option[YamlAverageCPUThresholdAlert] = None,
-                   containerKillThreshold: Option[YamlContainerKillThresholdAlert] = None,
-                   errorsLoggedThreshold: Option[YamlErrorsLoggedThresholdAlert] = None,
-                   exceptionThreshold: Option[YamlExceptionThresholdAlert] = None,
-                   logMessageThresholds: Option[Seq[YamlLogMessageThresholdAlert]] = None,
-                   http5xxThreshold: Option[YamlHttp5xxThresholdAlert] = None,
-                   http5xxPercentThreshold: Option[YamlHttp5xxPercentThresholdAlert] = None,
-                   httpStatusPercentThresholds: Option[Seq[YamlHttpStatusPercentThresholdAlert]] = None,
-                   httpStatusThresholds: Option[Seq[YamlHttpStatusThresholdAlert]] = None,
-                   httpTrafficThresholds: Option[Seq[YamlHttpTrafficThresholdAlert]] = None,
-                   totalHttpRequestThreshold: Option[YamlTotalHttpRequestThresholdAlert] = None,
-                   metricsThresholds: Option[Seq[YamlMetricsThresholdAlert]] = None,
-                   http90PercentileResponseTimeThreshold: Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = None,
-                 )
+  averageCPUThreshold: Option[YamlAverageCPUThresholdAlert] = None,
+  containerKillThreshold: Option[YamlContainerKillThresholdAlert] = None,
+  errorsLoggedThreshold: Option[YamlErrorsLoggedThresholdAlert] = None,
+  exceptionThreshold: Option[YamlExceptionThresholdAlert] = None,
+  logMessageThresholds: Option[Seq[YamlLogMessageThresholdAlert]] = None,
+  http5xxThreshold: Option[YamlHttp5xxThresholdAlert] = None,
+  http5xxPercentThreshold: Option[YamlHttp5xxPercentThresholdAlert] = None,
+  httpAbsolutePercentSplitThreshold: Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = None,
+  httpStatusPercentThresholds: Option[Seq[YamlHttpStatusPercentThresholdAlert]] = None,
+  httpStatusThresholds: Option[Seq[YamlHttpStatusThresholdAlert]] = None,
+  httpTrafficThresholds: Option[Seq[YamlHttpTrafficThresholdAlert]] = None,
+  totalHttpRequestThreshold: Option[YamlTotalHttpRequestThresholdAlert] = None,
+  metricsThresholds: Option[Seq[YamlMetricsThresholdAlert]] = None,
+  http90PercentileResponseTimeThreshold: Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = None,
+)
 
 case class PagerDuty(
-                      // name: String,
-                      integrationKeyName: String
-                      // slackChannel: String
-                    )
+  // name: String,
+  integrationKeyName: String
+  // slackChannel: String
+)

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
@@ -17,73 +17,83 @@
 package uk.gov.hmrc.alertconfig.builder.yaml
 
 case class YamlAverageCPUThresholdAlert(
-                                         count: Int
-                                       )
+  count: Int
+)
 
 case class YamlContainerKillThresholdAlert(
-                                            count: Int
-                                          )
+  count: Int
+)
 
 case class YamlErrorsLoggedThresholdAlert(
-                                           count: Int
-                                         )
+  count: Int
+)
 
 case class YamlExceptionThresholdAlert(
-                                        count: Int,
-                                        severity: String
-                                      )
+  count: Int,
+  severity: String
+)
 
 case class YamlHttp5xxPercentThresholdAlert(
-                                             percentage: Double,
-                                             severity: String
-                                           )
+  percentage: Double,
+  severity: String
+)
 
 case class YamlHttp5xxThresholdAlert(
-                                      count: Int,
-                                      severity: String
-                                    )
+  count: Int,
+  severity: String
+)
+
+case class YamlHttpAbsolutePercentSplitThresholdAlert(
+  percentThreshold: Double,
+  crossover: Int,
+  absoluteThreshold: Int,
+  hysteresis: Double,
+  excludeSpikes: Int,
+  errorFilter: String,
+  severity: String
+)
 
 case class YamlHttpStatusThresholdAlert(
-                                         count: Int = 1,
-                                         httpMethod: String,
-                                         httpStatus: Int,
-                                         severity: String
-                                       )
+  count: Int = 1,
+  httpMethod: String,
+  httpStatus: Int,
+  severity: String
+)
 
 case class YamlHttpStatusPercentThresholdAlert(
-                                                percentage: Double,
-                                                httpMethod: String,
-                                                httpStatus: Int,
-                                                severity: String
-                                              )
+  percentage: Double,
+  httpMethod: String,
+  httpStatus: Int,
+  severity: String
+)
 
 case class YamlLogMessageThresholdAlert(
-                                         count: Int,
-                                         lessThanMode: Boolean,
-                                         message: String,
-                                         severity: String
-                                       )
+  count: Int,
+  lessThanMode: Boolean,
+  message: String,
+  severity: String
+)
 
 case class YamlHttpTrafficThresholdAlert(
-                                          count: Int,
-                                          maxMinutesBelowThreshold: Int,
-                                          severity: String
-                                        )
+  count: Int,
+  maxMinutesBelowThreshold: Int,
+  severity: String
+)
 
 case class YamlMetricsThresholdAlert(
-                                      count: Double,
-                                      name: String,
-                                      query: String,
-                                      severity: String,
-                                      invert: Boolean
-                                    )
+  count: Double,
+  name: String,
+  query: String,
+  severity: String,
+  invert: Boolean
+)
 
 case class YamlTotalHttpRequestThresholdAlert(
-                                               count: Int
-                                             )
+  count: Int
+)
 
 case class YamlHttp90PercentileResponseTimeThresholdAlert(
-                                      timePeriod: Int,
-                                      count: Int,
-                                      severity: String
-                                   )
+  timePeriod: Int,
+  count: Int,
+  severity: String
+)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -375,8 +375,9 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "excludeSpikes"     -> JsNumber(0),
           "hysteresis"        -> JsNumber(1.0),
           "percentThreshold"  -> JsNumber(100.0),
-          "severity"          -> JsString("critical")
-        ))
+          "severity"          -> JsString("critical"),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+      ))
 
       serviceConfig("absolute-percentage-split-threshold") shouldBe expected
     }
@@ -475,8 +476,9 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         "excludeSpikes"     -> JsNumber(excludeSpikes),
         "hysteresis"        -> JsNumber(hysteresis),
         "percentThreshold"  -> JsNumber(percent),
-        "severity"          -> JsString("warning")
-      ))
+        "severity"          -> JsString("warning"),
+        "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString))
+    )
 
     serviceConfig("absolute-percentage-split-threshold") shouldBe expected
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -173,8 +173,9 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "excludeSpikes"     -> JsNumber(spikes),
           "hysteresis"        -> JsNumber(hysteresis),
           "percentThreshold"  -> JsNumber(percent),
-          "severity"          -> JsString(severity.toString)
-        ))
+          "severity"          -> JsString(severity.toString),
+          "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
+      ))
 
       service1Config("absolute-percentage-split-threshold") shouldBe expected
       service2Config("absolute-percentage-split-threshold") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -338,6 +338,14 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       output.http5xxThreshold shouldBe None
     }
 
+    "httpAbsolutePercentSplitThreshold should be disabled by default" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.httpAbsolutePercentSplitThreshold shouldBe None
+    }
+
     "HttpStatusPercentThreshold should be disabled by default" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
 


### PR DESCRIPTION
What did we do?
--

1. We now generate yaml for the HttpAbsolutePercentSplitThreshold alerts

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4438

Evidence of work
--

1. 
![image](https://github.com/hmrc/alert-config-builder/assets/60072280/05820325-781d-43d2-829e-82abc695eca6)

2. 
![image](https://github.com/hmrc/alert-config-builder/assets/60072280/bfef6813-60c3-49ed-9e96-0fbd54fba4fc)


Next Steps
--

1. Merge
2. Check that the Alert-Simulator config exists in the S3 bucket as it rolls out through the environments

Risks
--

1. ?

Collaboration
--

Co-authored-by: Muhammed Ahmed [ma3574@users.noreply.github.com](mailto:ma3574@users.noreply.github.com)