### PR TITLE
TEL-4446 Adds optional 5xx count baseline to 5xxPercentThreshold alarm

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -73,6 +73,7 @@ case class AlertConfigBuilder(
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
    * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
+   * Defaults to 1, which would mean the parameter has no effec
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object
@@ -286,7 +287,7 @@ case class TeamAlertConfigBuilder(
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
    * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night.
-   * Defaults to -1.
+   * Defaults to 1, which would mean the parameter has no effect.
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -68,10 +68,20 @@ case class AlertConfigBuilder(
                            alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
+  /**
+   * @param percentThreshold The %age of requests that must be 5xx to trigger the alarm
+   * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
+   * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
+   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
+   * @param severity How severe the alert is
+   * @param alertingPlatform Which platform to direct the alert to
+   * @return Configured threshold object
+   */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
+                                  minimumHttp5xxCountThreshold: Int = -1,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform = alertingPlatform))
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
@@ -271,10 +281,20 @@ case class TeamAlertConfigBuilder(
                            alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
+  /**
+   * @param percentThreshold The %age of requests that must be 5xx to trigger the alarm
+   * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
+   * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
+   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
+   * @param severity How severe the alert is
+   * @param alertingPlatform Which platform to direct the alert to
+   * @return Configured threshold object
+   */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
+                                  minimumHttp5xxCountThreshold: Int = -1,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, severity, alertingPlatform))
+    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
 
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -73,13 +73,13 @@ case class AlertConfigBuilder(
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
    * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
-   * Defaults to 1, which would mean the parameter has no effec
+   * Defaults to 0, which would mean the parameter has no effect
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object
    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
-                                  minimumHttp5xxCountThreshold: Int = 1,
+                                  minimumHttp5xxCountThreshold: Int = 0,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
@@ -287,13 +287,13 @@ case class TeamAlertConfigBuilder(
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
    * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night.
-   * Defaults to 1, which would mean the parameter has no effect.
+   * Defaults to 0, which would mean the parameter has no effect.
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object
    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
-                                  minimumHttp5xxCountThreshold: Int = 1,
+                                  minimumHttp5xxCountThreshold: Int = 0,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -285,7 +285,8 @@ case class TeamAlertConfigBuilder(
    * @param percentThreshold The %age of requests that must be 5xx to trigger the alarm
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
-   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
+   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night.
+   * Defaults to -1.
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -78,7 +78,7 @@ case class AlertConfigBuilder(
    * @return Configured threshold object
    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
-                                  minimumHttp5xxCountThreshold: Int = -1,
+                                  minimumHttp5xxCountThreshold: Int = 1,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
@@ -292,7 +292,7 @@ case class TeamAlertConfigBuilder(
    * @return Configured threshold object
    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
-                                  minimumHttp5xxCountThreshold: Int = -1,
+                                  minimumHttp5xxCountThreshold: Int = 1,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -20,6 +20,7 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 
 case class Http5xxPercentThreshold(
     percentage: Double = 100.0,
+    optionalMinimumHttp5xxCountThreshold: Int = -1,
     severity: AlertSeverity = AlertSeverity.Critical,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
@@ -29,7 +30,7 @@ object Http5xxPercentThresholdProtocol {
 
   implicit val thresholdFormat: JsonFormat[Http5xxPercentThreshold] = {
     implicit val asf: JsonFormat[AlertSeverity] = alertSeverityFormat
-    jsonFormat3(Http5xxPercentThreshold)
+    jsonFormat4(Http5xxPercentThreshold)
   }
 
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -20,7 +20,7 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 
 case class Http5xxPercentThreshold(
     percentage: Double = 100.0,
-    minimumHttp5xxCountThreshold: Int = 1,
+    minimumHttp5xxCountThreshold: Int = 0,
     severity: AlertSeverity = AlertSeverity.Critical,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -20,7 +20,7 @@ import spray.json.{DefaultJsonProtocol, JsonFormat}
 
 case class Http5xxPercentThreshold(
     percentage: Double = 100.0,
-    optionalMinimumHttp5xxCountThreshold: Int = -1,
+    minimumHttp5xxCountThreshold: Int = 1,
     severity: AlertSeverity = AlertSeverity.Critical,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -667,6 +667,24 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     )
   }
 
+  "configure http5xxPercentThreshold with count and percentage thresholds when the alerting platform is Sensu" in {
+    val threshold = 13.3
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      .withHttp5xxPercentThreshold(threshold, 10)
+      .build
+      .get
+      .parseJson
+      .asJsObject
+      .fields
+
+    serviceConfig("5xx-percent-threshold") shouldBe JsObject(
+      "severity"         -> JsString("critical"),
+      "optionalMinimumHttp5xxCountThreshold" -> JsNumber(10),
+      "percentage"       -> JsNumber(threshold),
+      "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+    )
+  }
+
   "disable http5xxPercentThreshold in Sensu when the alerting platform is Grafana" in {
     val threshold         = 13.3
     val disabledThreshold = 333.33

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -54,7 +54,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       )
       config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(1),
         "percentage"       -> JsNumber(100),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -661,7 +661,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
-      "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+      "minimumHttp5xxCountThreshold" -> JsNumber(1),
       "percentage"       -> JsNumber(threshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
@@ -679,7 +679,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
-      "optionalMinimumHttp5xxCountThreshold" -> JsNumber(10),
+      "minimumHttp5xxCountThreshold" -> JsNumber(10),
       "percentage"       -> JsNumber(threshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
@@ -698,7 +698,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
-      "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+      "minimumHttp5xxCountThreshold" -> JsNumber(1),
       "percentage"       -> JsNumber(disabledThreshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
     )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -54,6 +54,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       )
       config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
+        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
         "percentage"       -> JsNumber(100),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -660,6 +661,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
+      "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
       "percentage"       -> JsNumber(threshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
@@ -678,6 +680,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
+      "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
       "percentage"       -> JsNumber(disabledThreshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
     )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -54,7 +54,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       )
       config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "minimumHttp5xxCountThreshold" -> JsNumber(1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "percentage"       -> JsNumber(100),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -661,7 +661,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
-      "minimumHttp5xxCountThreshold" -> JsNumber(1),
+      "minimumHttp5xxCountThreshold" -> JsNumber(0),
       "percentage"       -> JsNumber(threshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
@@ -698,7 +698,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"         -> JsString("critical"),
-      "minimumHttp5xxCountThreshold" -> JsNumber(1),
+      "minimumHttp5xxCountThreshold" -> JsNumber(0),
       "percentage"       -> JsNumber(disabledThreshold),
       "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
     )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -272,13 +272,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "minimumHttp5xxCountThreshold" -> JsNumber(1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "minimumHttp5xxCountThreshold" -> JsNumber(1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -300,13 +300,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "minimumHttp5xxCountThreshold" -> JsNumber(1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "percentage"       -> JsNumber(disabledThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "minimumHttp5xxCountThreshold" -> JsNumber(1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "percentage"       -> JsNumber(disabledThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
@@ -753,7 +753,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(12.2),
-        "minimumHttp5xxCountThreshold" -> JsNumber(1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -793,7 +793,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(disabledThreshold),
-        "minimumHttp5xxCountThreshold" -> JsNumber(1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -272,11 +272,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
+        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
         "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
+        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
         "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -298,11 +300,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
+        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
         "percentage"       -> JsNumber(disabledThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
+        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
         "percentage"       -> JsNumber(disabledThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
@@ -749,6 +753,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(12.2),
+        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -769,6 +774,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(disabledThreshold),
+        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -272,13 +272,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(1),
         "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(1),
         "percentage"       -> JsNumber(threshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -300,13 +300,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(1),
         "percentage"       -> JsNumber(disabledThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"         -> JsString("critical"),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(1),
         "percentage"       -> JsNumber(disabledThreshold),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
@@ -753,7 +753,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(12.2),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(1),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -772,7 +772,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(12.2),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(15),
+        "minimumHttp5xxCountThreshold" -> JsNumber(15),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -793,7 +793,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(disabledThreshold),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(-1),
+        "minimumHttp5xxCountThreshold" -> JsNumber(1),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )
@@ -814,7 +814,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "percentage"       -> JsNumber(disabledThreshold),
-        "optionalMinimumHttp5xxCountThreshold" -> JsNumber(12),
+        "minimumHttp5xxCountThreshold" -> JsNumber(12),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
       )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -38,7 +38,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       alertConfigBuilder.averageCPUThreshold shouldBe AverageCPUThreshold(Int.MaxValue, AlertingPlatform.Default)
       alertConfigBuilder.containerKillThreshold shouldBe ContainerKillThreshold(1, AlertingPlatform.Default)
       alertConfigBuilder.exceptionThreshold shouldBe ExceptionThreshold(2, AlertSeverity.Critical)
-      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(100, AlertSeverity.Critical)
+      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(100, severity = AlertSeverity.Critical)
       alertConfigBuilder.http5xxThreshold shouldBe Http5xxThreshold(Int.MaxValue, AlertSeverity.Critical)
       alertConfigBuilder.http90PercentileResponseTimeThresholds shouldBe List()
       alertConfigBuilder.httpAbsolutePercentSplitThresholds shouldBe List()
@@ -131,9 +131,9 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     "return TeamAlertConfigBuilder with correct 5xxPercentThreshold" in {
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
-        .withHttp5xxPercentThreshold(19.2, AlertSeverity.Warning)
+        .withHttp5xxPercentThreshold(19.2, severity = AlertSeverity.Warning)
 
-      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(19.2, AlertSeverity.Warning)
+      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(19.2, severity = AlertSeverity.Warning)
     }
 
     "return TeamAlertConfigBuilder with correct handlers" in {
@@ -741,7 +741,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
-        .withHttp5xxPercentThreshold(12.2, AlertSeverity.Warning)
+        .withHttp5xxPercentThreshold(12.2, severity = AlertSeverity.Warning)
 
       alertConfigBuilder.services shouldBe Seq("service1")
       val configs                              = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
@@ -761,7 +761,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
-        .withHttp5xxPercentThreshold(threshold, AlertSeverity.Warning, AlertingPlatform.Grafana)
+        .withHttp5xxPercentThreshold(threshold, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
 
       alertConfigBuilder.services shouldBe Seq("service1")
       val configs                              = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -60,7 +60,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           .withErrorsLoggedThreshold(4, alertingPlatform = AlertingPlatform.Grafana)
           .withExceptionThreshold(1, AlertSeverity.Warning, AlertingPlatform.Grafana)
           .withHttp5xxThreshold(1, AlertSeverity.Warning, AlertingPlatform.Grafana)
-          .withHttp5xxPercentThreshold(1, AlertSeverity.Warning, AlertingPlatform.Grafana)
+          .withHttp5xxPercentThreshold(1, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
           .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1), critical = None))
           .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(severity = AlertSeverity.Warning))
           .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(severity = AlertSeverity.Warning))
@@ -71,7 +71,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           .withHttpStatusThreshold(HttpStatusThreshold(httpStatus = HttpStatus.HTTP_STATUS_501, severity = AlertSeverity.Critical))
           .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_500, severity = AlertSeverity.Warning))
           .withMetricsThreshold(MetricsThreshold("metrics", "query", warning = Some(1), critical = None))
-          .withLogMessageThreshold("HelloWorld", 1, lessThanMode = false, AlertSeverity.Warning, AlertingPlatform.Grafana)
+          .withLogMessageThreshold("HelloWorld", 1, lessThanMode = false, AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
           .withTotalHttpRequestsCountThreshold(2, AlertingPlatform.Grafana)
           .withAverageCPUThreshold(1, AlertingPlatform.Grafana)
       )
@@ -124,7 +124,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
         )
           .withExceptionThreshold(9, AlertSeverity.Warning, AlertingPlatform.Grafana)
           .withContainerKillThreshold(Int.MaxValue, AlertingPlatform.Grafana)
-          .withHttp5xxPercentThreshold(Int.MaxValue, AlertSeverity.Warning, AlertingPlatform.Grafana)
+          .withHttp5xxPercentThreshold(Int.MaxValue, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
       )
 
       val fakeConfig = new AlertConfig {
@@ -176,7 +176,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
         )
           .withExceptionThreshold(9, AlertSeverity.Critical, AlertingPlatform.Grafana)
           .withContainerKillThreshold(Int.MaxValue, AlertingPlatform.Grafana)
-          .withHttp5xxPercentThreshold(Int.MaxValue, AlertSeverity.Warning, AlertingPlatform.Grafana)
+          .withHttp5xxPercentThreshold(Int.MaxValue, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
       )
 
       val fakeConfig = new AlertConfig {
@@ -228,7 +228,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           .withErrorsLoggedThreshold(4, alertingPlatform = AlertingPlatform.Grafana)
           .withExceptionThreshold(1, AlertSeverity.Critical, AlertingPlatform.Grafana)
           .withHttp5xxThreshold(1, AlertSeverity.Critical, AlertingPlatform.Grafana)
-          .withHttp5xxPercentThreshold(1, AlertSeverity.Critical, AlertingPlatform.Grafana)
+          .withHttp5xxPercentThreshold(1, severity = AlertSeverity.Critical, alertingPlatform = AlertingPlatform.Grafana)
           .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(2), critical = Some(1)))
           .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(severity = AlertSeverity.Critical))
           .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(severity = AlertSeverity.Critical))
@@ -239,7 +239,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           .withHttpStatusThreshold(HttpStatusThreshold(httpStatus = HttpStatus.HTTP_STATUS_501, severity = AlertSeverity.Critical))
           .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_500, severity = AlertSeverity.Critical))
           .withMetricsThreshold(MetricsThreshold("metrics", "query", warning = Some(1), critical = Some(1)))
-          .withLogMessageThreshold("HelloWorld", 1,lessThanMode = false, AlertSeverity.Critical, AlertingPlatform.Grafana)
+          .withLogMessageThreshold("HelloWorld", 1, lessThanMode = false, AlertSeverity.Critical, alertingPlatform = AlertingPlatform.Grafana)
           .withTotalHttpRequestsCountThreshold(2, AlertingPlatform.Grafana)
           .withAverageCPUThreshold(1, AlertingPlatform.Grafana)
       )


### PR DESCRIPTION
What did we do?
--

1. Added an option 5xx count baseline to the 5xxPercentageThreshold.
2. This defaults to 1 which will tell `telemetry-grafana-alert-config` to in effect ignore it.
3. This means that the alert can be the same in every case - it will always have a minimum count threshold

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4446

Evidence of work
--

1. Automated tests

Next Steps
--

1. Update `alert-config` to support this modified DSL and output the new parameter in Yaml
2. Update `telemetry-grafana-alert-config` to support this parameter and test on a lab <== this is the tricky bit

Risks
--

1. Are the changes I have made to the DSL acceptable?
3. Is it clear that this parameter is optional?
4. Is there a better way to do this?

Collaboration
--

Co-authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>
