### PR TITLE
TEL-4446 Adds output objects for convertHttp5xxPercentThresholds

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -73,7 +73,7 @@ case class AlertConfigBuilder(
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
    * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
-   * Defaults to 0, which would mean the parameter has no effect
+   * Defaults to 0, which would mean the parameter has no effect. Only applies in Grafana-based alerting, NOT supported on Sensu.
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object
@@ -287,7 +287,7 @@ case class TeamAlertConfigBuilder(
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
    * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night.
-   * Defaults to 0, which would mean the parameter has no effect.
+   * Defaults to 0, which would mean the parameter has no effect. Only applies in Grafana-based alerting, NOT supported on Sensu.
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -143,6 +143,7 @@ object AlertsYamlBuilder {
     Option.when(isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold) && http5xxPercentThreshold.percentage <= 100.0)(
       YamlHttp5xxPercentThresholdAlert(
         percentage = http5xxPercentThreshold.percentage,
+        minimumHttp5xxCountThreshold = http5xxPercentThreshold.minimumHttp5xxCountThreshold,
         severity = http5xxPercentThreshold.severity.toString
       )
     )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
@@ -35,6 +35,7 @@ case class YamlExceptionThresholdAlert(
 
 case class YamlHttp5xxPercentThresholdAlert(
   percentage: Double,
+  minimumHttp5xxCountThreshold: Int,
   severity: String
 )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -124,7 +124,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
         )
           .withExceptionThreshold(9, AlertSeverity.Warning, AlertingPlatform.Grafana)
           .withContainerKillThreshold(Int.MaxValue, AlertingPlatform.Grafana)
-          .withHttp5xxPercentThreshold(Int.MaxValue, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
+          .withHttp5xxPercentThreshold(Int.MaxValue, 1, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
       )
 
       val fakeConfig = new AlertConfig {
@@ -176,7 +176,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
         )
           .withExceptionThreshold(9, AlertSeverity.Critical, AlertingPlatform.Grafana)
           .withContainerKillThreshold(Int.MaxValue, AlertingPlatform.Grafana)
-          .withHttp5xxPercentThreshold(Int.MaxValue, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
+          .withHttp5xxPercentThreshold(Int.MaxValue, 1, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
       )
 
       val fakeConfig = new AlertConfig {
@@ -327,7 +327,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
-      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(100.0, "critical"))
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(100.0, 0, "critical"))
     }
 
     "Http5xxThreshold should be disabled by default" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -180,7 +180,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, "critical"))
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, 0, "critical"))
     }
 
     "Http5xxPercentThreshold should be disabled if alertingPlatform is Sensu" in {
@@ -198,7 +198,16 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
-      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, "critical"))
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, 0, "critical"))
+    }
+
+    "Http5xxPercentThreshold should be enabled by default in integration, supporting minimumHttp5xxCountThreshold" in {
+      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+        .withHttp5xxPercentThreshold(60, 5)
+
+      val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
+
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60, 5, "critical"))
     }
 
     "Http5xxPercentThreshold should be disabled by default in production" in {


### PR DESCRIPTION
What did we do?
--

1. Prior PR #111 was only part of what I needed; this change means it can write to the services.yml

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4446

Evidence of work
--

1.

Next Steps
--

1. 

Risks
--

1. This is not supported in Sensu alerts

Collaboration
--

Co-authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>

