### PR TITLE
TEL-4470 Adds Scaladoc annotations

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -52,23 +52,72 @@ case class AlertConfigBuilder(
 
   val logger = new Logger()
 
+  /**
+   * Sets handlers for the configuration, e.g. .withHandlers("dass-cyclone")
+   * @param string The name of your pagerduty integration. This integration must already exist in PagerDuty;
+   *               alert-config will not create it for you.
+   */
   def withHandlers(handlers: String*) =
     this.copy(handlers = handlers)
 
+  /**
+   * This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
+   *
+   * @param errorsLoggedThreshold The number of logs at ERROR level that this alert will trigger on
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window
+   * }
+   * </pre>
+   */
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold, alertingPlatform))
 
+  /**
+   * This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
+   * @param count The number of exceptions thrown that this alert will trigger on
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical)
+   * }
+   * </pre>
+   */
   def withExceptionThreshold(exceptionThreshold: Int,
                              severity: AlertSeverity = AlertSeverity.Critical,
                              alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity, alertingPlatform = alertingPlatform))
 
+  /**
+   * This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+   *
+   * @param http5xxThreshold The number of all http responses with a 5xx status code to alert on
+   * @param severity Whether to raise the alert as critical or warning
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window
+   * .withHttp5xxThreshold(5, AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window
+   * }
+   * </pre>
+   */
   def withHttp5xxThreshold(http5xxThreshold: Int,
                            severity: AlertSeverity = AlertSeverity.Critical,
                            alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
   /**
+   * This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+   *
+   * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+   *
    * @param percentThreshold The %age of requests that must be 5xx to trigger the alarm
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
@@ -77,6 +126,14 @@ case class AlertConfigBuilder(
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object
+   * @example
+   * <pre>
+   * {@code
+   * .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
+   * .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window
+   * .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window
+   * }
+   * </pre>
    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   minimumHttp5xxCountThreshold: Int = 0,
@@ -84,6 +141,17 @@ case class AlertConfigBuilder(
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
 
+  /**
+   * This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
+   * @param threshold Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000), timePeriod = 7))
+   * }
+   * </pre>
+   */
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
@@ -92,18 +160,79 @@ case class AlertConfigBuilder(
     }
   }
 
+  /**
+   * @param threshold
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499"))
+   * }
+   * </pre>
+   */
   def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) =
     this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 
+  /**
+   * @param threshold
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(10.0, 0, -1, 1.1, 2, "status:>498", "nps-hod-service",AlertSeverity.Critical))
+   * }
+   * </pre>
+   */
   def withHttpAbsolutePercentSplitDownstreamServiceThreshold(threshold: HttpAbsolutePercentSplitDownstreamServiceThreshold) =
     this.copy(httpAbsolutePercentSplitDownstreamServiceThresholds = httpAbsolutePercentSplitDownstreamServiceThresholds :+ threshold)
 
+  /**
+   * @param threshold
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(10.0, 0, -1, 1.1, 2, "status:>498", "nps-hod-service",AlertSeverity.Critical))
+   * }
+   * </pre>
+   */
   def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold) =
     this.copy(httpAbsolutePercentSplitDownstreamHodThresholds = httpAbsolutePercentSplitDownstreamHodThresholds :+ threshold)
 
+  /**
+   * This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within a 15-minute window.
+   * @param threshold Object with fields httpStatus, count, severity and httpMethod
+   * @return
+   *
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
+   * }
+   * </pre>
+   */
   def withHttpStatusThreshold(threshold: HttpStatusThreshold) =
     this.copy(httpStatusThresholds = httpStatusThresholds :+ threshold)
 
+  /**
+   * This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
+   *
+   * One or both of warning and critical must be given.
+   *
+   * @param threshold
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
+   * }
+   */
   def withHttpTrafficThreshold(threshold: HttpTrafficThreshold) = {
     if (httpTrafficThresholds.nonEmpty) {
       throw new Exception("withHttpTrafficThreshold has already been defined for this microservice")
@@ -112,18 +241,84 @@ case class AlertConfigBuilder(
     }
   }
 
+  /**
+   * This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
+   *
+   * @param threshold
+   * @return
+   * <pre>
+   * {@code
+   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status code 404 in a 15-minute window
+   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all requests return status code 500 in a 15-minute window
+   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window
+   * }
+   * </pre>
+   */
   def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
+  /**
+   * This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
+   *
+   * @param threshold
+   * @return
+   * <pre>
+   * {@code
+   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_audit", query = "sumSeries(play.address-lookup.ecs*.audit.failure.count)", warning = Some(4), critical = Some(6)))
+   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_reject_audit", query = "integral(sumSeries(play.address-lookup.ecs*.audit.{failure,reject}.count))", critical = Some(10)))
+   * }
+   * </pre>
+   */
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
 
+  /**
+   * All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed with an out-of-memory exception.
+   * This alert will notify when a specified number of containers are killed within a 15-minute window.
+   *
+   * @param containerCrashThreshold The number of container kills to alert on
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * <pre>
+   * {@code
+   * .withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute window
+   * }
+   * </pre>
+   */
   def withContainerKillThreshold(containerCrashThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerCrashThreshold, alertingPlatform))
 
+  /**
+   * This alert will notify when your microservice receives a given number of requests within a 15-minute window.
+   *
+   * @param threshold The number of all http requests to alert on
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * <pre>
+   * {@code
+   * .withTotalHttpRequestsCountThreshold(1000) # alert when 1000 requests are received in a 15-minute window
+   * }
+   * </pre>
+   */
   def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold, alertingPlatform))
 
+  /**
+   * This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
+   * @param message The substring to search for in the log message
+   * @param threshold The threshold above which an alert will be raised
+   * @param lessThanMode Flips the logic so that an alert is raised if less than the threshold amount is detected
+   * @param severity The severity to set for this check in PagerDuty
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * <pre>
+   * {@code
+   * .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
+   * .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute window
+   * .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs containing `MY_LOG_MESSAGE` are detected
+   * .withLogMessageThreshold("MY_LOG_MESSAGE", 2, alertingPlatform = AlertingPlatform.Grafan) // Raise an alert through Grafana when a service generates two or more logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe.
+   * }
+   */
   def withLogMessageThreshold(message: String,
                               threshold: Int,
                               lessThanMode: Boolean = false,
@@ -131,9 +326,30 @@ case class AlertConfigBuilder(
                               alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
+  /**
+   * This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
+   *
+   * @param averageCPUThreshold The average percentage CPU used by all instances of your microservice
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
+   * }
+   * </pre>
+   */
   def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(averageCPUThreshold = AverageCPUThreshold(averageCPUThreshold, alertingPlatform = alertingPlatform))
 
+  /**
+   * In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service.
+   * However, since platform services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to your configBuilder.
+   *
+   * @deprecated Custom alerting coming soon!
+   * @param platformService True if you are defining alerts for something that is NOT a standard microservice
+   * @return
+   */
   def isPlatformService(platformService: Boolean): AlertConfigBuilder =
     this.copy(platformService = platformService)
 
@@ -266,31 +482,88 @@ case class TeamAlertConfigBuilder(
     platformService: Boolean = false
 ) extends Builder[Seq[AlertConfigBuilder]] {
 
+  /**
+   * Sets handlers for the configuration, e.g. .withHandlers("dass-cyclone")
+   * @param string The name of your pagerduty integration. This integration must already exist in PagerDuty;
+   *               alert-config will not create it for you.
+   */
   def withHandlers(handlers: String*) =
     this.copy(handlers = handlers)
 
+  /**
+   * This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
+   *
+   * @param errorsLoggedThreshold The number of logs at ERROR level that this alert will trigger on
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window
+   * }
+   * </pre>
+   */
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold, alertingPlatform))
 
+  /**
+   * This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
+   * @param count The number of exceptions thrown that this alert will trigger on
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical)
+   * }
+   * </pre>
+   */
   def withExceptionThreshold(exceptionThreshold: Int,
                              severity: AlertSeverity = AlertSeverity.Critical,
                              alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity, alertingPlatform = alertingPlatform))
 
+  /**
+   * This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+   *
+   * @param http5xxThreshold The number of all http responses with a 5xx status code to alert on
+   * @param severity Whether to raise the alert as critical or warning
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window
+   * .withHttp5xxThreshold(5, AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window
+   * }
+   * </pre>
+   */
   def withHttp5xxThreshold(http5xxThreshold: Int,
                            severity: AlertSeverity = AlertSeverity.Critical,
                            alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
   /**
+   * This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+   *
+   * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+   *
    * @param percentThreshold The %age of requests that must be 5xx to trigger the alarm
    * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
    * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
-   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night.
+   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
    * Defaults to 0, which would mean the parameter has no effect. Only applies in Grafana-based alerting, NOT supported on Sensu.
    * @param severity How severe the alert is
    * @param alertingPlatform Which platform to direct the alert to
    * @return Configured threshold object
+   * @example
+   * <pre>
+   * {@code
+   * .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
+   * .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window
+   * .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window
+   * }
+   * </pre>
    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   minimumHttp5xxCountThreshold: Int = 0,
@@ -298,6 +571,17 @@ case class TeamAlertConfigBuilder(
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
 
+  /**
+   * This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
+   * @param threshold Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000), timePeriod = 7))
+   * }
+   * </pre>
+   */
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
@@ -310,6 +594,16 @@ case class TeamAlertConfigBuilder(
     }
   }
 
+  /**
+   * @param threshold
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499"))
+   * }
+   * </pre>
+   */
   def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) =
     this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 
@@ -322,6 +616,22 @@ case class TeamAlertConfigBuilder(
   def withContainerKillThreshold(containerKillThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerKillThreshold, alertingPlatform))
 
+  /**
+   * This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
+   *
+   * One or both of warning and critical must be given.
+   *
+   * @param threshold
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
+   * }
+   */
   def withHttpTrafficThreshold(threshold: HttpTrafficThreshold) = {
     if (httpTrafficThresholds.nonEmpty) {
       throw new Exception("withHttpTrafficThreshold has already been defined for this microservice")
@@ -330,18 +640,86 @@ case class TeamAlertConfigBuilder(
     }
   }
 
+  /**
+   * This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within a 15-minute window.
+   * @param threshold Object with fields httpStatus, count, severity and httpMethod
+   * @return
+   *
+   * @example
+   * <pre>
+   * {@code
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
+   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
+   * }
+   * </pre>
+   */
   def withHttpStatusThreshold(threshold: HttpStatusThreshold) =
     this.copy(httpStatusThresholds = httpStatusThresholds :+ threshold)
 
+  /**
+   * This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
+   *
+   * @param threshold
+   * @return
+   * <pre>
+   * {@code
+   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status code 404 in a 15-minute window
+   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all requests return status code 500 in a 15-minute window
+   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window
+   * }
+   * </pre>
+   */
   def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
+  /**
+   * This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
+   *
+   * @param threshold
+   * @return
+   * <pre>
+   * {@code
+   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_audit", query = "sumSeries(play.address-lookup.ecs*.audit.failure.count)", warning = Some(4), critical = Some(6)))
+   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_reject_audit", query = "integral(sumSeries(play.address-lookup.ecs*.audit.{failure,reject}.count))", critical = Some(10)))
+   * }
+   * </pre>
+   */
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
 
+  /**
+   * This alert will notify when your microservice receives a given number of requests within a 15-minute window.
+   *
+   * @param threshold The number of all http requests to alert on
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * <pre>
+   * {@code
+   * .withTotalHttpRequestsCountThreshold(1000) # alert when 1000 requests are received in a 15-minute window
+   * }
+   * </pre>
+   */
   def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold, alertingPlatform))
 
+  /**
+   * This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
+   * @param message The substring to search for in the log message
+   * @param threshold The threshold above which an alert will be raised
+   * @param lessThanMode Flips the logic so that an alert is raised if less than the threshold amount is detected
+   * @param severity The severity to set for this check in PagerDuty
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * <pre>
+   * {@code
+   * .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
+   * .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute window
+   * .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs containing `MY_LOG_MESSAGE` are detected
+   * .withLogMessageThreshold("MY_LOG_MESSAGE", 2, alertingPlatform = AlertingPlatform.Grafan) // Raise an alert through Grafana when a service generates two or more logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe.
+   * }
+   */
   def withLogMessageThreshold(message: String,
                               threshold: Int,
                               lessThanMode: Boolean = false,
@@ -349,9 +727,30 @@ case class TeamAlertConfigBuilder(
                               alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
+  /**
+   * This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
+   *
+   * @param averageCPUThreshold The average percentage CPU used by all instances of your microservice
+   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
+   * @return
+   * @example
+   * <pre>
+   * {@code
+   * .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
+   * }
+   * </pre>
+   */
   def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(averageCPUThreshold = AverageCPUThreshold(averageCPUThreshold, alertingPlatform = alertingPlatform))
 
+  /**
+   * In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service.
+   * However, since platform services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to your configBuilder.
+   *
+   * @deprecated Custom alerting coming soon!
+   * @param platformService True if you are defining alerts for something that is NOT a standard microservice
+   * @return
+   */
   def isPlatformService(platformService: Boolean): TeamAlertConfigBuilder =
     this.copy(platformService = platformService)
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
@@ -16,6 +16,10 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
+/**
+ * An enumeration of sorts that encapsulates all the possible alert severities supported
+ * by alert-config
+ */
 sealed trait AlertSeverity
 
 object AlertSeverity {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertingPlatform.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertingPlatform.scala
@@ -18,16 +18,30 @@ package uk.gov.hmrc.alertconfig.builder
 
 sealed trait AlertingPlatform
 
+/**
+ * Configuration object to select an alerting platform
+ * Defaults can be seen in GrafanaMigration
+ * @see GrafanaMigration.scala
+ */
 object AlertingPlatform {
 
+  /**
+   * Specifies the default alerting platform
+   */
   object Default extends AlertingPlatform {
     override def toString: String = "Default"
   }
 
+  /**
+   * Specifies the alerting platform to be Grafana
+   */
   object Grafana extends AlertingPlatform {
     override def toString: String = "Grafana"
   }
 
+  /**
+   * Specifies the alerting platform to be Sensu
+   */
   object Sensu extends AlertingPlatform {
     override def toString: String = "Sensu"
   }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AverageCPUThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AverageCPUThreshold.scala
@@ -16,7 +16,19 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
+/**
+ * This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
+ * @param count The average percentage CPU used by all instances of your microservice
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class AverageCPUThreshold(
+    /**
+     * The average percentage CPU used by all instances of your microservice
+     */
     count: Int = Int.MaxValue,
+
+    /**
+     * The platform this alert will target. We are migrating towards Grafana and away from Sensu
+     */
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
@@ -16,6 +16,13 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
+/**
+ * All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed with an out-of-memory exception.
+ * This alert will notify when a specified number of containers are killed within a 15-minute window.
+ *
+ * @param count The number of container kills to alert on
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class ContainerKillThreshold(
     count: Int = Int.MaxValue,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
@@ -18,6 +18,12 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
+/**
+ *This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
+ * @param count The number of exceptions thrown that this alert will trigger on
+ * @param severity Whether to raise the alert as critical or warning
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class ExceptionThreshold(
     count: Int = 2,
     severity: AlertSeverity = AlertSeverity.Critical,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -37,6 +37,12 @@ object AlertType {
   object Http90PercentileResponseTimeThreshold extends AlertType
 }
 
+/**
+ * This class determines which standard alerts go where in each environment.
+ *
+ * This is so that the Telemetry team can safely migrate alerts gradually rather
+ * than "big bang"ing them out
+ */
 object GrafanaMigration {
 
   val config = Map(
@@ -159,11 +165,20 @@ object GrafanaMigration {
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     )
   )
-    def isGrafanaEnabled(alertingPlatform: AlertingPlatform, currentEnvironment: Environment, alertType: AlertType): Boolean = {
-      alertingPlatform match {
-        case AlertingPlatform.Sensu => false
-        case AlertingPlatform.Grafana => true
-        case _ => config(currentEnvironment)(alertType) == AlertingPlatform.Grafana
-      }
+
+  /**
+   *
+   * @param alertingPlatform Alerting platform to test for Grafana being enabled
+   * @param currentEnvironment env to test for Grafana being enabled
+   * @param alertType alert type to test for Grafana being enabled
+   * @return True if the alerting platform matches the data { alertingPlatform, currentEnvironment, alertType }.
+   *         All 3 must be matches for the stated alert in the stated env at the states severity to be Grafana-ised.
+   */
+  def isGrafanaEnabled(alertingPlatform: AlertingPlatform, currentEnvironment: Environment, alertType: AlertType): Boolean = {
+    alertingPlatform match {
+      case AlertingPlatform.Sensu => false
+      case AlertingPlatform.Grafana => true
+      case _ => config(currentEnvironment)(alertType) == AlertingPlatform.Grafana
     }
+  }
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -18,6 +18,16 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
+/**
+ * This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+ *
+ * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+ *
+ * @param percentage The percentage of all http responses with a 5xx status code to alert on
+ * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in. Useful if, for example, you don't want to alert on just a one-off 5xx in the middle of the night. Only supported on Grafana-based alerts.
+ * @param severity Whether to raise the alert as critical or warning
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class Http5xxPercentThreshold(
     percentage: Double = 100.0,
     minimumHttp5xxCountThreshold: Int = 0,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
@@ -18,6 +18,12 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
+/**
+ * This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+ * @param count The number of all http responses with a 5xx status code to alert on
+ * @param severity Whether to raise the alert as critical or warning
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class Http5xxThreshold(
     count: Int = Int.MaxValue,
     severity: AlertSeverity = AlertSeverity.Critical,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http90PercentileThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http90PercentileThreshold.scala
@@ -18,6 +18,16 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
+/**
+ * This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
+ *
+ * One or both of warning and critical must be given.
+ *
+ * @param warning The response time in millisecond above which a warning level alert will be raised
+ * @param critical The response time in millisecond above which a critical level alert will be raised
+ * @param timePeriod How far back to consider in minutes. Default is 15 minutes. Range: 1 - 15 (inclusive)
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class Http90PercentileResponseTimeThreshold(
     warning: Option[Int],
     critical: Option[Int],

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusPercentThreshold.scala
@@ -18,6 +18,14 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
+/**
+ * This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
+ * @param httpStatus The http status code that this alert will trigger on (429, 499-504)
+ * @param percentage The percentage of all http responses with the given status code to alert on
+ * @param severity Whether to raise the alert as critical or warning
+ * @param httpMethod The http method to filter all requests by (one of All, Post, Get, Put, Delete)
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class HttpStatusPercentThreshold(
     httpStatus: HttpStatus.HTTP_STATUS,
     percentage: Double = 100.0,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
@@ -18,6 +18,14 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
+/**
+ * This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within a 15-minute window.
+ * @param httpStatus The http status code that this alert will trigger on (429, 499-504)
+ * @param count The number of http responses with the given status code to alert on
+ * @param severity Whether to raise the alert as critical or warning
+ * @param httpMethod The http method to filter all requests by (one of All, Post, Get, Put, Delete)
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class HttpStatusThreshold(
     httpStatus: HttpStatus.HTTP_STATUS,
     count: Int = 1,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpTrafficThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpTrafficThreshold.scala
@@ -18,6 +18,16 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
+/**
+ * This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
+ *
+ * One or both of warning and critical must be given.
+ *
+ * @param warning The number of http requests below which a warning level alert will be raised
+ * @param critical The number of http requests below which a critical level alert will be raised
+ * @param maxMinutesBelowThreshold The number of minutes over which the threshold breaching triggers an alert
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class HttpTrafficThreshold(
     warning: Option[Int],
     critical: Option[Int],

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
@@ -18,7 +18,17 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-// By default we alert if the count of messages is >= threshold. If lessThanMode is set we alert if < threshold
+/**
+ * This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
+ *
+ * By default we alert if the count of messages is >= threshold. If lessThanMode is set we alert if < threshold
+ *
+ * @param message The substring to search for in the log message
+ * @param count The threshold above which an alert will be raised
+ * @param lessThanMode If true, flips the logic so that an alert is raised if less than the threshold amount is detected
+ * @param severity The severity to set for this check in PagerDuty
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class LogMessageThreshold(
     message: String,
     count: Int,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/MetricsThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/MetricsThreshold.scala
@@ -18,6 +18,18 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
+/**
+ * This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
+ *
+ * One or both of warning and critical must be given.
+ *
+ * @param name A unique name to give this alert, which will be used as the name of the alert in PagerDuty
+ * @param query The metric path to use to trigger this alert
+ * @param warning The response time in millisecond above which a warning level alert will be raised
+ * @param critical The response time in millisecond above which a critical level alert will be raised
+ * @param invert Set to true to invert the threshold (trigger on below instead of above)
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class MetricsThreshold(
     name: String,
     query: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
@@ -16,6 +16,12 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
+/**
+ * This alert will notify when your microservice receives a given number of requests within a 15-minute window.
+ *
+ * @param count The number of all http requests to alert on
+ * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
+ */
 case class TotalHttpRequestThreshold(
     count: Int = Int.MaxValue,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default


### PR DESCRIPTION
What did we do?
--

1. Added Scaladoc annotations

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4470

Evidence of work
--

1. `sbt doc` generates viable docs
![image](https://github.com/hmrc/alert-config-builder/assets/205245/795d224a-37ab-48c7-82cb-aa9e75b9b770)

Next Steps
--

1. Update alert-config to use the newest version
2. **Assert that** alert-config in IDE offers intellisense-like help

Risks
--

1. We now have the documentation in 2 places: alert-config README and in the source code
