### PR TITLE
TEL-4431 Migrate httpStatusPercentThreshold alert to Grafana ALerting…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -139,7 +139,7 @@ object GrafanaMigration {
       AlertType.Http5xxPercentThreshold -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
       AlertType.Http5xxThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Sensu,
+      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
       AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -180,30 +180,17 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       )
     }
 
-    "configure http status percent threshold with given thresholds and severities" in {
+    "disable http status percent threshold with given thresholds and severities, when alerting platform is Grafana" in {
       val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
-        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post))
-        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_504, 4.4))
+        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana))
+        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_504, 4.4, alertingPlatform = AlertingPlatform.Grafana))
         .build
         .get
         .parseJson
         .asJsObject
         .fields
 
-      serviceConfig("httpStatusPercentThresholds") shouldBe JsArray(
-        JsObject(
-          "httpStatus"       -> JsNumber(502),
-          "percentage"       -> JsNumber(2.2),
-          "severity"         -> JsString("warning"),
-          "httpMethod"       -> JsString("POST"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
-        JsObject(
-          "httpStatus"       -> JsNumber(504),
-          "percentage"       -> JsNumber(4.4),
-          "severity"         -> JsString("critical"),
-          "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
-      )
+      serviceConfig("httpStatusPercentThresholds") shouldBe JsArray()
     }
 
     "disable http status percent threshold when alerting platform is Grafana" in {
@@ -219,23 +206,16 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       serviceConfig("httpStatusPercentThresholds") shouldBe JsArray()
     }
 
-    "configure http status percent threshold with given status code using default threshold" in {
+    "disable http status percent threshold with given status code using default threshold, when alerting platform is grafana" in {
       val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
-        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS(404)))
+        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS(404), alertingPlatform = AlertingPlatform.Grafana))
         .build
         .get
         .parseJson
         .asJsObject
         .fields
 
-      serviceConfig("httpStatusPercentThresholds") shouldBe JsArray(
-        JsObject(
-          "httpStatus"       -> JsNumber(404),
-          "percentage"       -> JsNumber(100.0),
-          "severity"         -> JsString("critical"),
-          "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
-      )
+      serviceConfig("httpStatusPercentThresholds") shouldBe JsArray()
     }
 
     "disable http 5xx threshold in Sensu when alerting platform is Grafana" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -662,10 +662,9 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct httpStatusPercentThresholds" in {
-      val threshold1 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_500, 19.1, AlertSeverity.Warning, HttpMethod.Post)
-      val threshold2 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_501, 20)
-      val threshold3 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS(555), 55.5)
-      // threshold4 should not appear in sensu (json) output as alerting platform is Grafana
+      val threshold1 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_500, 19.1, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana)
+      val threshold2 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_501, 20, alertingPlatform = AlertingPlatform.Grafana)
+      val threshold3 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS(555), 55.5, alertingPlatform = AlertingPlatform.Grafana)
       val threshold4 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 10, alertingPlatform = AlertingPlatform.Grafana)
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
@@ -681,26 +680,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      val expected = JsArray(
-        JsObject(
-          "httpStatus"       -> JsNumber(500),
-          "percentage"       -> JsNumber(19.1),
-          "severity"         -> JsString("warning"),
-          "httpMethod"       -> JsString("POST"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
-        JsObject(
-          "httpStatus"       -> JsNumber(501),
-          "percentage"       -> JsNumber(20),
-          "severity"         -> JsString("critical"),
-          "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
-        JsObject(
-          "httpStatus"       -> JsNumber(555),
-          "percentage"       -> JsNumber(55.5),
-          "severity"         -> JsString("critical"),
-          "httpMethod"       -> JsString("ALL_METHODS"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
-      )
+      val expected = JsArray()
 
       service1Config("httpStatusPercentThresholds") shouldBe expected
       service2Config("httpStatusPercentThresholds") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -317,13 +317,13 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       output.httpStatusPercentThresholds shouldBe Some(List(YamlHttpStatusPercentThresholdAlert(60, "ALL_METHODS", 500, "critical")))
     }
 
-    "HttpStatusPercentThreshold should be disabled by default in production" in {
+    "HttpStatusPercentThreshold should be enabled by default in production" in {
       val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.httpStatusPercentThresholds shouldBe None
+      output.httpStatusPercentThresholds shouldBe Some(List(YamlHttpStatusPercentThresholdAlert(60.0, "ALL_METHODS", 500, "critical")))
     }
 
     "HttpStatusThreshold should be enabled if alertingPlatform is Grafana" in {


### PR DESCRIPTION
… in production

What did we do?
--

1. Migrate this alert from Sensu to GA in production

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4431

Evidence of work
--

1. N/A

Next Steps
--

1. Update alert-config with new version of builder
2. Ensure pipeline has rolled out succesfully
3. "To check this has worked effectively, find a service which has this alert configured and validate that it appears in https://grafana-alerting.mdtp-production.telemetry.tax.service.gov.uk/alerting/list and does not appear in the ElasticSearch PagerDuty mappings (instructions here: https://github.com/hmrc/telemetry/blob/main/snippets/elasticsearch.md#fetch-for-a-given-service)."

Risks
--

1. Something goes wrong - so we roll back.
