### PR TITLE
TEL-4469 Replace handler with integrations where appropriate

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfig.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.alertconfig.builder
 trait AlertConfig {
   def alertConfig: Seq[AlertConfigBuilder]
 
-  def environmentConfig: Seq[EnvironmentAlertBuilder] = alertConfig.flatMap(_.handlers).map(EnvironmentAlertBuilder(_))
+  def environmentConfig: Seq[EnvironmentAlertBuilder] = alertConfig.flatMap(_.integrations).map(EnvironmentAlertBuilder(_))
 
   implicit def teamAlertConfigToAlertConfigs(config: TeamAlertConfigBuilder): Seq[AlertConfigBuilder] = config.build
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -28,7 +28,7 @@ trait Builder[T] {
 
 case class AlertConfigBuilder(
     serviceName: String,
-    handlers: Seq[String] = Seq("noop"),
+    integrations: Seq[String] = Seq("noop"),
     errorsLoggedThreshold: ErrorsLoggedThreshold = ErrorsLoggedThreshold(),
     exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
     http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
@@ -53,12 +53,12 @@ case class AlertConfigBuilder(
   val logger = new Logger()
 
   /**
-   * Sets handlers for the configuration, e.g. .withHandlers("dass-cyclone")
+   * Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
    * @param string The name of your pagerduty integration. This integration must already exist in PagerDuty;
    *               alert-config will not create it for you.
    */
-  def withHandlers(handlers: String*) =
-    this.copy(handlers = handlers)
+  def withIntegrations(integrations: String*) =
+    this.copy(integrations = integrations)
 
   /**
    * This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
@@ -421,7 +421,7 @@ case class AlertConfigBuilder(
           s"""
              |{
              |"app": "$serviceName.$serviceDomain",
-             |"handlers": ${handlers.toJson.compactPrint},
+             |"handlers": ${integrations.toJson.compactPrint},
              |"errors-logged-threshold":$updatedErrorsLoggedThreshold,
              |"exception-threshold":${exceptionThreshold
               .copy(count = updatedExceptionThreshold)
@@ -462,7 +462,7 @@ case class AlertConfigBuilder(
 
 case class TeamAlertConfigBuilder(
     services: Seq[String],
-    handlers: Seq[String] = Seq("noop"),
+    integrations: Seq[String] = Seq("noop"),
     errorsLoggedThreshold: ErrorsLoggedThreshold = ErrorsLoggedThreshold(),
     exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
     http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
@@ -483,12 +483,12 @@ case class TeamAlertConfigBuilder(
 ) extends Builder[Seq[AlertConfigBuilder]] {
 
   /**
-   * Sets handlers for the configuration, e.g. .withHandlers("dass-cyclone")
+   * Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
    * @param string The name of your pagerduty integration. This integration must already exist in PagerDuty;
    *               alert-config will not create it for you.
    */
-  def withHandlers(handlers: String*) =
-    this.copy(handlers = handlers)
+  def withIntegrations(integrations: String*) =
+    this.copy(integrations = integrations)
 
   /**
    * This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
@@ -771,7 +771,7 @@ case class TeamAlertConfigBuilder(
     services.map(service =>
       AlertConfigBuilder(
         service,
-        handlers,
+        integrations,
         errorsLoggedThreshold,
         exceptionThreshold,
         http5xxThreshold,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -74,11 +74,11 @@ object AllEnvironmentAlertConfigBuilder {
 }
 
 case class EnvironmentAlertBuilder(
-    handlerName: String,
+    integrationName: String,
     command: Option[JsValue] = None,
     enabledEnvironments: Map[Environment, Set[Severity]] = Map((Environment.Production, Set(Severity.Ok, Severity.Warning, Severity.Critical))),
     customEnvironmentNames: Map[Environment, String] = Map((Environment.Production, "aws_production")),
-    handlerFilters: Map[Environment, JsValue] = Map((Environment.Production, JsString("occurrences")))
+    integrationFilters: Map[Environment, JsValue] = Map((Environment.Production, JsString("occurrences")))
 ) {
 
   private val defaultSeverities: Set[Severity] = Set(Severity.Ok, Severity.Warning, Severity.Critical)
@@ -93,7 +93,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Integration       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Integration -> customEnv),
-      handlerFilters = handlerFilters + (Environment.Integration                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Integration                 -> customFilter)
     )
 
   def inDevelopment(
@@ -104,7 +104,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Development       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Development -> customEnv),
-      handlerFilters = handlerFilters + (Environment.Development                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Development                 -> customFilter)
     )
 
   def inQa(
@@ -115,7 +115,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Qa       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Qa -> customEnv),
-      handlerFilters = handlerFilters + (Environment.Qa                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Qa                 -> customFilter)
     )
 
   def inStaging(
@@ -126,7 +126,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Staging       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Staging -> customEnv),
-      handlerFilters = handlerFilters + (Environment.Staging                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Staging                 -> customFilter)
     )
 
   def inExternalTest(
@@ -137,7 +137,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.ExternalTest       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.ExternalTest -> customEnv),
-      handlerFilters = handlerFilters + (Environment.ExternalTest                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.ExternalTest                 -> customFilter)
     )
 
   def inManagement(
@@ -148,7 +148,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Management       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Management -> customEnv),
-      handlerFilters = handlerFilters + (Environment.Management                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Management                 -> customFilter)
     )
 
   def inProduction(
@@ -159,7 +159,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Production       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Production -> customEnv),
-      handlerFilters = handlerFilters + (Environment.Production                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Production                 -> customFilter)
     )
 
   def disableProduction(): EnvironmentAlertBuilder =
@@ -170,17 +170,17 @@ case class EnvironmentAlertBuilder(
 
   def alertConfigFor(environment: Environment): (String, JsObject) = {
     val filterType: String =
-      if (handlerFilters.getOrElse(environment, defaultFilter).isInstanceOf[JsArray])
+      if (integrationFilters.getOrElse(environment, defaultFilter).isInstanceOf[JsArray])
         "filters"
       else
         "filter"
 
-    handlerName ->
+    integrationName ->
       JsObject(
-        "command"      -> commandFor(handlerName, environment),
+        "command"      -> commandFor(integrationName, environment),
         "type"         -> JsString("pipe"),
         "severities"   -> severitiesFor(environment),
-        s"$filterType" -> handlerFilters.getOrElse(environment, defaultFilter)
+        s"$filterType" -> integrationFilters.getOrElse(environment, defaultFilter)
       )
   }
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -93,7 +93,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Integration       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Integration -> customEnv),
-      integrationFilters = integrationFilters + (Environment.Integration                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Integration         -> customFilter)
     )
 
   def inDevelopment(
@@ -104,7 +104,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Development       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Development -> customEnv),
-      integrationFilters = integrationFilters + (Environment.Development                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Development         -> customFilter)
     )
 
   def inQa(
@@ -115,7 +115,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Qa       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Qa -> customEnv),
-      integrationFilters = integrationFilters + (Environment.Qa                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Qa         -> customFilter)
     )
 
   def inStaging(
@@ -126,7 +126,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Staging       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Staging -> customEnv),
-      integrationFilters = integrationFilters + (Environment.Staging                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Staging         -> customFilter)
     )
 
   def inExternalTest(
@@ -137,7 +137,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.ExternalTest       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.ExternalTest -> customEnv),
-      integrationFilters = integrationFilters + (Environment.ExternalTest                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.ExternalTest         -> customFilter)
     )
 
   def inManagement(
@@ -148,7 +148,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Management       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Management -> customEnv),
-      integrationFilters = integrationFilters + (Environment.Management                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Management         -> customFilter)
     )
 
   def inProduction(
@@ -159,7 +159,7 @@ case class EnvironmentAlertBuilder(
     this.copy(
       enabledEnvironments = enabledEnvironments + (Environment.Production       -> severities),
       customEnvironmentNames = customEnvironmentNames + (Environment.Production -> customEnv),
-      integrationFilters = integrationFilters + (Environment.Production                 -> customFilter)
+      integrationFilters = integrationFilters + (Environment.Production         -> customFilter)
     )
 
   def disableProduction(): EnvironmentAlertBuilder =

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -37,18 +37,18 @@ object IntegrationsYamlBuilder {
         // This is a clumsy implementation of adding the INFO status.
         //
         // It must only be added for:
-        // 1. the "team-telemetry-heartbeat" handler
+        // 1. the "team-telemetry-heartbeat" integration
         // 2. in YAML (for Grafana)
         //
         // If we turn it on in Sensu, the entirety of Sensu crashes HARD! see TEL-4404
-        if (builder.handlerName.equals("team-telemetry-heartbeat")) {
+        if (builder.integrationName.equals("team-telemetry-heartbeat")) {
           Integration(
-            name = builder.handlerName,
+            name = builder.integrationName,
             severitiesEnabled = Seq(Critical, Warning, Info).map(_.toString)
           )
         } else {
           Integration(
-            name = builder.handlerName,
+            name = builder.integrationName,
             severitiesEnabled = enabledSeverities.filter(Seq(Critical, Warning, Info).contains(_)).map(_.toString).toSeq
           )
         }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -32,7 +32,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   "AlertConfigBuilder" should {
     "build correct config" in {
 
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withContainerKillThreshold(56)
         .build
         .get
@@ -69,7 +69,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "build correct config for platform service" in {
-      val platformServiceConfig = AlertConfigBuilder("ingress-gateway", handlers = Seq("h1", "h2"))
+      val platformServiceConfig = AlertConfigBuilder("ingress-gateway", integrations = Seq("h1", "h2"))
         .isPlatformService(true)
         .withContainerKillThreshold(1)
         .build
@@ -86,31 +86,31 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       System.setProperty("app-config-path", "this-directory-does-not-exist")
 
       intercept[FileNotFoundException] {
-        AlertConfigBuilder("service1", handlers = Seq("h1", "h2")).build.get.parseJson.asJsObject.fields
+        AlertConfigBuilder("service1", integrations = Seq("h1", "h2")).build.get.parseJson.asJsObject.fields
       }
     }
 
     "Returns None when app config file not found" in {
-      AlertConfigBuilder("absent-service", handlers = Seq("h1", "h2")).build shouldBe None
+      AlertConfigBuilder("absent-service", integrations = Seq("h1", "h2")).build shouldBe None
     }
 
     "Returns None when app config file exists but zone key is absent" in {
-      AlertConfigBuilder("service-with-absent-zone-key", handlers = Seq("h1", "h2")).build shouldBe None
+      AlertConfigBuilder("service-with-absent-zone-key", integrations = Seq("h1", "h2")).build shouldBe None
     }
 
     "Returns None when app config file exists but it unparsable" in {
-      AlertConfigBuilder("service-with-unparseable-app-config", handlers = Seq("h1", "h2")).build shouldBe None
+      AlertConfigBuilder("service-with-unparseable-app-config", integrations = Seq("h1", "h2")).build shouldBe None
     }
 
     "Maps the correct service domain" in {
-      val service2Config = AlertConfigBuilder("service2", handlers = Seq("h1", "h2")).build.get.parseJson.asJsObject.fields
-      val service3Config = AlertConfigBuilder("service3", handlers = Seq("h1", "h2")).build.get.parseJson.asJsObject.fields
+      val service2Config = AlertConfigBuilder("service2", integrations = Seq("h1", "h2")).build.get.parseJson.asJsObject.fields
+      val service3Config = AlertConfigBuilder("service3", integrations = Seq("h1", "h2")).build.get.parseJson.asJsObject.fields
       service2Config("app") shouldBe JsString("service2.domain.zone.2")
       service3Config("app") shouldBe JsString("service3.domain.zone.3")
     }
 
     "configure http status threshold with given thresholds and severities" in {
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_502, 2, AlertSeverity.Warning, HttpMethod.Post))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_504, 4))
         .build
@@ -138,7 +138,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "configure http status threshold with given thresholds and severities only if alerting platform is Sensu" in {
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusThreshold(
           HttpStatusThreshold(HttpStatus.HTTP_STATUS_502, 2, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_504, 4))
@@ -161,7 +161,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "configure http status threshold with given status code using default threshold" in {
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS(404)))
         .build
         .get
@@ -181,7 +181,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "disable http status percent threshold with given thresholds and severities, when alerting platform is Grafana" in {
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_504, 4.4, alertingPlatform = AlertingPlatform.Grafana))
         .build
@@ -194,7 +194,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "disable http status percent threshold when alerting platform is Grafana" in {
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post, AlertingPlatform.Grafana))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_504, 4.4, alertingPlatform = AlertingPlatform.Grafana))
         .build
@@ -207,7 +207,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "disable http status percent threshold with given status code using default threshold, when alerting platform is grafana" in {
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS(404), alertingPlatform = AlertingPlatform.Grafana))
         .build
         .get
@@ -219,7 +219,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "disable http 5xx threshold in Sensu when alerting platform is Grafana" in {
-      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxThreshold(2, AlertSeverity.Warning, AlertingPlatform.Grafana)
         .build
         .get
@@ -234,7 +234,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "configure http 5xx threshold severity with given thresholds and unspecified severity" in {
-      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxThreshold(2)
         .build
         .get
@@ -249,7 +249,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "configure logMessageThresholds with given thresholds only if alerting platform is Sensu" in {
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 3)
         .withLogMessageThreshold("SIMULATED_ERROR2", 4, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR3", 5, lessThanMode = true)
@@ -296,7 +296,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     "configure httpTrafficThreshold with given thresholds when alerting platform is Sensu" in {
       val threshold = HttpTrafficThreshold(Some(10), Some(5), 35)
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(threshold)
         .build
         .get
@@ -316,7 +316,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     "disable httpTrafficThreshold in Sensu when alerting platform is Grafana" in {
       val threshold = HttpTrafficThreshold(Some(10), Some(5), 35, AlertingPlatform.Grafana)
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(threshold)
         .build
         .get
@@ -340,7 +340,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     }
 
     "configure HttpAbsolutePercentSplitThreshold with default parameters" in {
-      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold())
         .build
         .get
@@ -365,7 +365,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     "configure metrics threshold with given warning and critical levels" in {
       val query = "some_function(over.some.query.for.anything.like*)"
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold(name = "alert1", query = query, warning = Some(65), critical = Some(88)))
         .withMetricsThreshold(MetricsThreshold(name = "alert1-warning-only", query = query, warning = Some(44)))
         .withMetricsThreshold(MetricsThreshold(name = "alert1-critical-only", query = query, critical = Some(45)))
@@ -408,7 +408,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     "disable metrics threshold where alerting platform is Grafana" in {
       val query = "some_function(over.some.query.for.anything.like*)"
-      val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold(name = "alert1", query = query, warning = Some(65), critical = Some(88)))
         .withMetricsThreshold(MetricsThreshold(name = "alert1-warning-only", query = query, warning = Some(44), alertingPlatform = AlertingPlatform.Grafana))
         .withMetricsThreshold(MetricsThreshold(name = "alert1-critical-only", query = query, critical = Some(45), alertingPlatform = AlertingPlatform.Grafana))
@@ -440,7 +440,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     val filter        = "Some error"
     val severity      = AlertSeverity.Warning
 
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttpAbsolutePercentSplitThreshold(
         HttpAbsolutePercentSplitThreshold(percent, crossOver, absolute, hysteresis, excludeSpikes, filter, severity))
       .build
@@ -474,7 +474,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     val target        = "service.invalid"
     val severity      = AlertSeverity.Warning
 
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttpAbsolutePercentSplitDownstreamServiceThreshold(
         HttpAbsolutePercentSplitDownstreamServiceThreshold(percent, crossOver, absolute, hysteresis, excludeSpikes, filter, target, severity))
       .build
@@ -508,7 +508,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     val target        = "hod-endpoint"
     val severity      = AlertSeverity.Warning
 
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttpAbsolutePercentSplitDownstreamHodThreshold(
         HttpAbsolutePercentSplitDownstreamHodThreshold(percent, crossOver, absolute, hysteresis, excludeSpikes, filter, target, severity))
       .build
@@ -532,23 +532,23 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     serviceConfig("absolute-percentage-split-downstream-hod-threshold") shouldBe expected
   }
 
-  "return config with correct handlers" in {
-    val handlers = Seq("a", "b")
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
-      .withHandlers(handlers: _*)
+  "return config with correct integrations" in {
+    val integrations = Seq("a", "b")
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
+      .withIntegrations(integrations: _*)
       .build
       .get
       .parseJson
       .asJsObject
       .fields
 
-    val expected = JsArray(handlers.map(JsString(_)).toVector)
+    val expected = JsArray(integrations.map(JsString(_)).toVector)
     serviceConfig("handlers") shouldBe expected
   }
 
   "configure ExceptionThreshold with given thresholds when the alerting platform is Sensu" in {
     val threshold = 12
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withExceptionThreshold(threshold)
       .build
       .get
@@ -567,7 +567,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "disable ExceptionThreshold in Sensu when alerting platform is Grafana" in {
     val threshold = 12
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withExceptionThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
       .build
       .get
@@ -586,7 +586,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "configure ExceptionThreshold with optional parameter severity" in {
     val threshold = 12
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withExceptionThreshold(threshold, AlertSeverity.Warning)
       .build
       .get
@@ -605,7 +605,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "configure ErrorsLoggedThreshold with given thresholds when the alerting platform is Sensu" in {
     val threshold = 12
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withErrorsLoggedThreshold(threshold)
       .build
       .get
@@ -618,7 +618,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "disable ErrorsLoggedThreshold in Sensu when the alerting platform is Grafana" in {
     val threshold = 3
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withErrorsLoggedThreshold(threshold, AlertingPlatform.Grafana)
       .build
       .get
@@ -631,7 +631,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "configure http5xxPercentThreshold with given thresholds when the alerting platform is Sensu" in {
     val threshold = 13.3
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold)
       .build
       .get
@@ -649,7 +649,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "configure http5xxPercentThreshold with count and percentage thresholds when the alerting platform is Sensu" in {
     val threshold = 13.3
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold, 10)
       .build
       .get
@@ -668,7 +668,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   "disable http5xxPercentThreshold in Sensu when the alerting platform is Grafana" in {
     val threshold         = 13.3
     val disabledThreshold = 333.33
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
       .build
       .get
@@ -686,7 +686,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "configure averageCPUThreshold with given thresholds" in {
     val threshold = 15
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withAverageCPUThreshold(threshold)
       .build
       .get
@@ -699,7 +699,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "disable averageCPUThreshold when the alerting platform is Grafana" in {
     val threshold = 15
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withAverageCPUThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
       .build
       .get
@@ -714,7 +714,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     EnvironmentVars.setEnv("ENVIRONMENT", "integration")
 
     val threshold = 15
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withAverageCPUThreshold(threshold)
       .build
       .get
@@ -731,7 +731,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     EnvironmentVars.setEnv("ENVIRONMENT", "integration")
 
     val threshold = 15
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withAverageCPUThreshold(threshold, alertingPlatform = AlertingPlatform.Sensu)
       .build
       .get
@@ -746,7 +746,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "use the configured value for containerKillThreshold when the alerting platform is Sensu" in {
     val threshold = 3
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withContainerKillThreshold(threshold)
       .build
       .get
@@ -759,7 +759,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "disable containerKillThreshold in Sensu when the alerting platform is Grafana" in {
     val threshold = 3
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withContainerKillThreshold(threshold, AlertingPlatform.Grafana)
       .build
       .get
@@ -771,7 +771,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   }
 
   "disable http request count threshold with given threshold when alerting platform is Grafana" in {
-    val serviceConfig = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withTotalHttpRequestsCountThreshold(500, AlertingPlatform.Grafana)
       .build
       .get
@@ -783,7 +783,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   }
 
   "disable http 5xx threshold in Sensu when alerting platform is Grafana" in {
-    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+    val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withTotalHttpRequestsCountThreshold(500, AlertingPlatform.Grafana)
       .build
       .get

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -23,7 +23,7 @@ import spray.json.{JsArray, JsObject, JsString}
 
 class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers with BeforeAndAfterEach {
 
-  def defaultNoopHandlerConfig: JsObject =
+  def defaultNoopIntegrationConfig: JsObject =
     JsObject(
       "command"    -> JsString("/etc/sensu/handlers/noop.rb"),
       "type"       -> JsString("pipe"),
@@ -31,7 +31,7 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
       "filter"     -> JsString("occurrences")
     )
 
-  def defaultEnabledHandlerConfig(service: String, environment: Environment): JsObject =
+  def defaultEnabledIntegrationConfig(service: String, environment: Environment): JsObject =
     JsObject(
       "command"    -> JsString(s"/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team $service -e $environment"),
       "type"       -> JsString("pipe"),
@@ -48,8 +48,8 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
         environmentConfigMap(e) shouldBe
           JsObject(
             "handlers" -> JsObject(
-              "infra"          -> defaultNoopHandlerConfig,
-              "team-telemetry" -> defaultNoopHandlerConfig
+              "infra"          -> defaultNoopIntegrationConfig,
+              "team-telemetry" -> defaultNoopIntegrationConfig
             ))
       }
     }
@@ -61,8 +61,8 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
     environmentConfigMap(Environment.Production) shouldBe
       JsObject(
         "handlers" -> JsObject(
-          "infra"          -> defaultEnabledHandlerConfig("infra", Environment.Production),
-          "team-telemetry" -> defaultEnabledHandlerConfig("team-telemetry", Environment.Production)
+          "infra"          -> defaultEnabledIntegrationConfig("infra", Environment.Production),
+          "team-telemetry" -> defaultEnabledIntegrationConfig("team-telemetry", Environment.Production)
         ))
   }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -34,7 +34,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val alertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
 
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
-      alertConfigBuilder.handlers shouldBe Seq("noop")
+      alertConfigBuilder.integrations shouldBe Seq("noop")
       alertConfigBuilder.averageCPUThreshold shouldBe AverageCPUThreshold(Int.MaxValue, AlertingPlatform.Default)
       alertConfigBuilder.containerKillThreshold shouldBe ContainerKillThreshold(1, AlertingPlatform.Default)
       alertConfigBuilder.exceptionThreshold shouldBe ExceptionThreshold(2, AlertSeverity.Critical)
@@ -136,13 +136,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(19.2, severity = AlertSeverity.Warning)
     }
 
-    "return TeamAlertConfigBuilder with correct handlers" in {
-      val handlers = Seq("a", "b")
+    "return TeamAlertConfigBuilder with correct integrations" in {
+      val integrations = Seq("a", "b")
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
-        .withHandlers(handlers: _*)
+        .withIntegrations(integrations: _*)
 
-      alertConfigBuilder.handlers shouldBe handlers
+      alertConfigBuilder.integrations shouldBe integrations
     }
 
     "return TeamAlertConfigBuilder with correct AbsolutePercentSplitThresholds" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -31,7 +31,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
   "convertAlerts(alertConfigBuilder)" should {
     "averageCPUThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withAverageCPUThreshold(60, AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -40,7 +40,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "averageCPUThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withAverageCPUThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -49,7 +49,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "averageCPUThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withAverageCPUThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -58,7 +58,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "averageCPUThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withAverageCPUThreshold(60, AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -67,7 +67,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "containerKillThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withContainerKillThreshold(60, AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -76,7 +76,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "containerKillThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withContainerKillThreshold(60, AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -85,7 +85,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "containerKillThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withContainerKillThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -94,7 +94,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "containerKillThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withContainerKillThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -103,7 +103,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ErrorsLoggedThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60, AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -112,7 +112,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ErrorsLoggedThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60, AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -121,7 +121,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ErrorsLoggedThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -130,7 +130,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ErrorsLoggedThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withErrorsLoggedThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -139,7 +139,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ExceptionThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withExceptionThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -148,7 +148,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ExceptionThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withExceptionThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -157,7 +157,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ExceptionThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withExceptionThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -166,7 +166,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "ExceptionThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withExceptionThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -175,7 +175,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxPercentThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -184,7 +184,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxPercentThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -193,7 +193,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxPercentThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -202,7 +202,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxPercentThreshold should be enabled by default in integration, supporting minimumHttp5xxCountThreshold" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60, 5)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -211,7 +211,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxPercentThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -220,7 +220,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxThreshold(60, alertingPlatform = AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -229,7 +229,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxThreshold(60, alertingPlatform = AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -238,7 +238,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -247,7 +247,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "Http5xxThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttp5xxPercentThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -256,7 +256,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "httpAbsolutePercentSplitThreshold should be enabled if alertPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(
           percentThreshold = 50,
           crossOver = 1,
@@ -274,7 +274,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "httpAbsolutePercentSplitThreshold should be disabled if alertPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(
           percentThreshold = 50,
           crossOver = 1,
@@ -291,7 +291,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusPercentThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Grafana))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -300,7 +300,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusPercentThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Sensu))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -309,7 +309,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusPercentThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -318,7 +318,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusPercentThreshold should be enabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS(500), 60))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -327,7 +327,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Grafana))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -336,7 +336,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60, alertingPlatform = AlertingPlatform.Sensu))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -345,7 +345,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -354,7 +354,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpStatusThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(500), 60))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -363,7 +363,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpTrafficThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60), alertingPlatform = AlertingPlatform.Grafana))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -372,7 +372,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpTrafficThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60), alertingPlatform = AlertingPlatform.Sensu))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -381,7 +381,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpTrafficThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60)))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -390,7 +390,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "HttpTrafficThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60)))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -399,7 +399,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "LogMessageThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60, alertingPlatform = AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -408,7 +408,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "LogMessageThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60, alertingPlatform = AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -417,7 +417,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "LogMessageThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -426,7 +426,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "LogMessageThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withLogMessageThreshold("LOG_MESSAGE", 60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -435,7 +435,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "MetricsThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1), alertingPlatform = AlertingPlatform.Grafana))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -444,7 +444,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "MetricsThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1), alertingPlatform = AlertingPlatform.Sensu))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -453,7 +453,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "MetricsThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1)))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -462,7 +462,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "MetricsThreshold should be disabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold("metric", "a.b.c.d", None, Some(1)))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -471,7 +471,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "TotalHttpRequestThreshold should be enabled if alertingPlatform is Grafana" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60, AlertingPlatform.Grafana)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
@@ -480,7 +480,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "TotalHttpRequestThreshold should be disabled if alertingPlatform is Sensu" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60, AlertingPlatform.Sensu)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -489,7 +489,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "TotalHttpRequestThreshold should be enabled by default in integration" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
@@ -498,7 +498,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
     }
 
     "TotalHttpRequestThreshold should be enabled by default in production" in {
-      val config = AlertConfigBuilder("service1", handlers = Seq("h1", "h2"))
+      val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withTotalHttpRequestsCountThreshold(60)
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)


### PR DESCRIPTION
What did we do?
--

1. In order to replace the outdated Sensu 'handler' term with 'Integration' in alert-config, we needed to make changes to the models themselves in the alert-config-builder.

This PR replaces the word handler with Integration, whereever it is appropriate. 

**Exceptions (Where I have left the term 'handler' for now)**:
- Where we actually generate the json
<img width="503" alt="image" src="https://github.com/hmrc/alert-config-builder/assets/60072280/1c5d5fc2-8545-43c9-81f5-78fd18a8114b">

- Where we create the expected json object in the EnvironmentAlertBuilder
<img width="681" alt="image" src="https://github.com/hmrc/alert-config-builder/assets/60072280/27904c96-76ce-4eb5-ac92-321bbc733826">

- Where we define the actual command ran by Sensu:
<img width="679" alt="image" src="https://github.com/hmrc/alert-config-builder/assets/60072280/e43307e6-b84a-4837-b416-38625d865c50">


References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4469

Evidence of work
--

Published this locally, and updated alert-config using it. All tests passed.
![image](https://github.com/hmrc/alert-config-builder/assets/60072280/86bd223d-bb6f-46bf-a590-b0b279505d26)


Next Steps
--

1. merge this
2. Make a copy of the various alert config artefacts locally
3. Merge my follow-on alert-config PR
4. Verify that no unexpected differences occur in the newly generated alert config artefacts
5. Announce the change on slack

Risks
--

1. I have been too gung ho. But the tests are all passing, and I've left the 3 important bits alone. 

Collaboration
--

Co-authored-by: Gavin Davies [gavD@users.noreply.github.com](mailto:gavD@users.noreply.github.com)