### PR TITLE
TEL-4450 Prod & NonProd thresholds

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -52,106 +52,96 @@ case class AlertConfigBuilder(
 
   val logger = new Logger()
 
-  /**
-   * Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
-   * @param string The name of your pagerduty integration. This integration must already exist in PagerDuty;
-   *               alert-config will not create it for you.
-   */
+  /** Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
+    * @param string
+    *   The name of your pagerduty integration. This integration must already exist in PagerDuty; alert-config will not create it for you.
+    */
   def withIntegrations(integrations: String*) =
     this.copy(integrations = integrations)
 
-  /**
-   * This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
-   *
-   * @param errorsLoggedThreshold The number of logs at ERROR level that this alert will trigger on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
+    *
+    * @param errorsLoggedThreshold
+    *   The number of logs at ERROR level that this alert will trigger on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window } </pre>
+    */
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold, alertingPlatform))
 
-  /**
-   * This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
-   * @param count The number of exceptions thrown that this alert will trigger on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical)
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
+    * @param count
+    *   The number of exceptions thrown that this alert will trigger on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical) } </pre>
+    */
   def withExceptionThreshold(exceptionThreshold: Int,
                              severity: AlertSeverity = AlertSeverity.Critical,
                              alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity, alertingPlatform = alertingPlatform))
 
-  /**
-   * This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
-   *
-   * @param http5xxThreshold The number of all http responses with a 5xx status code to alert on
-   * @param severity Whether to raise the alert as critical or warning
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window
-   * .withHttp5xxThreshold(5, AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+    *
+    * @param http5xxThreshold
+    *   The number of all http responses with a 5xx status code to alert on
+    * @param severity
+    *   Whether to raise the alert as critical or warning
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window .withHttp5xxThreshold(5,
+    *   AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window } </pre>
+    */
   def withHttp5xxThreshold(http5xxThreshold: Int,
                            severity: AlertSeverity = AlertSeverity.Critical,
                            alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
-  /**
-   * This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
-   *
-   * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
-   *
-   * @param percentThreshold The %age of requests that must be 5xx to trigger the alarm
-   * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
-   * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
-   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
-   * Defaults to 0, which would mean the parameter has no effect. Only applies in Grafana-based alerting, NOT supported on Sensu.
-   * @param severity How severe the alert is
-   * @param alertingPlatform Which platform to direct the alert to
-   * @return Configured threshold object
-   * @example
-   * <pre>
-   * {@code
-   * .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
-   * .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window
-   * .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
+    * window.
+    *
+    * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+    *
+    * @param percentThreshold
+    *   The %age of requests that must be 5xx to trigger the alarm
+    * @param minimumHttp5xxCountThreshold
+    *   The minimum count of 5xxs that must be present for the percentThreshold check to kick in. Optional. If you want to create a
+    *   5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method to use. You want to use this parameter if, for
+    *   example, you don't want to alert on just a one-off 5xx in the middle of the night Defaults to 0, which would mean the parameter has no effect.
+    *   Only applies in Grafana-based alerting, NOT supported on Sensu.
+    * @param severity
+    *   How severe the alert is
+    * @param alertingPlatform
+    *   Which platform to direct the alert to
+    * @return
+    *   Configured threshold object
+    * @example
+    *   <pre> {@code .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
+    *   .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a
+    *   15-minute window .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx
+    *   status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window } </pre>
+    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   minimumHttp5xxCountThreshold: Int = 0,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
 
-  /**
-   * This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
-   * @param threshold Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000), timePeriod = 7))
-   * }
-   * </pre>
-   */
+  /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
+    * @param threshold
+    *   Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
+    * @return
+    * @example
+    *   <pre> {@code .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000),
+    *   timePeriod = 7)) } </pre>
+    */
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
@@ -160,79 +150,61 @@ case class AlertConfigBuilder(
     }
   }
 
-  /**
-   * @param threshold
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499"))
-   * }
-   * </pre>
-   */
+  /** @param threshold
+    * @return
+    * @example
+    *   <pre> {@code .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499")) } </pre>
+    */
   def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) =
     this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 
-  /**
-   * @param threshold
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(10.0, 0, -1, 1.1, 2, "status:>498", "nps-hod-service",AlertSeverity.Critical))
-   * }
-   * </pre>
-   */
+  /** @param threshold
+    * @return
+    * @example
+    *   <pre> {@code .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(10.0, 0, -1, 1.1, 2,
+    *   "status:>498", "nps-hod-service",AlertSeverity.Critical)) } </pre>
+    */
   def withHttpAbsolutePercentSplitDownstreamServiceThreshold(threshold: HttpAbsolutePercentSplitDownstreamServiceThreshold) =
     this.copy(httpAbsolutePercentSplitDownstreamServiceThresholds = httpAbsolutePercentSplitDownstreamServiceThresholds :+ threshold)
 
-  /**
-   * @param threshold
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(10.0, 0, -1, 1.1, 2, "status:>498", "nps-hod-service",AlertSeverity.Critical))
-   * }
-   * </pre>
-   */
+  /** @param threshold
+    * @return
+    * @example
+    *   <pre> {@code .withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(10.0, 0, -1, 1.1, 2,
+    *   "status:>498", "nps-hod-service",AlertSeverity.Critical)) } </pre>
+    */
   def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold) =
     this.copy(httpAbsolutePercentSplitDownstreamHodThresholds = httpAbsolutePercentSplitDownstreamHodThresholds :+ threshold)
 
-  /**
-   * This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within a 15-minute window.
-   * @param threshold Object with fields httpStatus, count, severity and httpMethod
-   * @return
-   *
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within
+    * a 15-minute window.
+    * @param threshold
+    *   Object with fields httpStatus, count, severity and httpMethod
+    * @return
+    *
+    * @example
+    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
+    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
+    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
+    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window } </pre>
+    */
   def withHttpStatusThreshold(threshold: HttpStatusThreshold) =
     this.copy(httpStatusThresholds = httpStatusThresholds :+ threshold)
 
-  /**
-   * This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
-   *
-   * One or both of warning and critical must be given.
-   *
-   * @param threshold
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
-   * }
-   */
+  /** This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
+    *
+    * One or both of warning and critical must be given.
+    *
+    * @param threshold
+    * @return
+    * @example
+    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
+    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
+    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
+    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window }
+    */
   def withHttpTrafficThreshold(threshold: HttpTrafficThreshold) = {
     if (httpTrafficThresholds.nonEmpty) {
       throw new Exception("withHttpTrafficThreshold has already been defined for this microservice")
@@ -241,84 +213,75 @@ case class AlertConfigBuilder(
     }
   }
 
-  /**
-   * This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
-   *
-   * @param threshold
-   * @return
-   * <pre>
-   * {@code
-   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status code 404 in a 15-minute window
-   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all requests return status code 500 in a 15-minute window
-   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
+    *
+    * @param threshold
+    * @return
+    *   <pre> {@code .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status
+    *   code 404 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all
+    *   requests return status code 500 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0,
+    *   AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window }
+    *   </pre>
+    */
   def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
-  /**
-   * This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
-   *
-   * @param threshold
-   * @return
-   * <pre>
-   * {@code
-   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_audit", query = "sumSeries(play.address-lookup.ecs*.audit.failure.count)", warning = Some(4), critical = Some(6)))
-   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_reject_audit", query = "integral(sumSeries(play.address-lookup.ecs*.audit.{failure,reject}.count))", critical = Some(10)))
-   * }
-   * </pre>
-   */
+  /** This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
+    *
+    * @param threshold
+    * @return
+    *   <pre> {@code .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_audit", query =
+    *   "sumSeries(play.address-lookup.ecs*.audit.failure.count)", warning = Some(4), critical = Some(6))) .withMetricsThreshold(MetricsThreshold(name
+    *   \= "address_lookup_failed_reject_audit", query = "integral(sumSeries(play.address-lookup.ecs*.audit.{failure,reject}.count))", critical =
+    *   Some(10))) } </pre>
+    */
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
 
-  /**
-   * All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed with an out-of-memory exception.
-   * This alert will notify when a specified number of containers are killed within a 15-minute window.
-   *
-   * @param containerCrashThreshold The number of container kills to alert on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * <pre>
-   * {@code
-   * .withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed
+    * with an out-of-memory exception. This alert will notify when a specified number of containers are killed within a 15-minute window.
+    *
+    * @param containerCrashThreshold
+    *   The number of container kills to alert on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    *   <pre> {@code .withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute
+    *   window } </pre>
+    */
   def withContainerKillThreshold(containerCrashThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerCrashThreshold, alertingPlatform))
 
-  /**
-   * This alert will notify when your microservice receives a given number of requests within a 15-minute window.
-   *
-   * @param threshold The number of all http requests to alert on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * <pre>
-   * {@code
-   * .withTotalHttpRequestsCountThreshold(1000) # alert when 1000 requests are received in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice receives a given number of requests within a 15-minute window.
+    *
+    * @param threshold
+    *   The number of all http requests to alert on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    *   <pre> {@code .withTotalHttpRequestsCountThreshold(1000) # alert when 1000 requests are received in a 15-minute window } </pre>
+    */
   def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold, alertingPlatform))
 
-  /**
-   * This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
-   * @param message The substring to search for in the log message
-   * @param threshold The threshold above which an alert will be raised
-   * @param lessThanMode Flips the logic so that an alert is raised if less than the threshold amount is detected
-   * @param severity The severity to set for this check in PagerDuty
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * <pre>
-   * {@code
-   * .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
-   * .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute window
-   * .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs containing `MY_LOG_MESSAGE` are detected
-   * .withLogMessageThreshold("MY_LOG_MESSAGE", 2, alertingPlatform = AlertingPlatform.Grafan) // Raise an alert through Grafana when a service generates two or more logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe.
-   * }
-   */
+  /** This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
+    * @param message
+    *   The substring to search for in the log message
+    * @param threshold
+    *   The threshold above which an alert will be raised
+    * @param lessThanMode
+    *   Flips the logic so that an alert is raised if less than the threshold amount is detected
+    * @param severity
+    *   The severity to set for this check in PagerDuty
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    *   <pre> {@code .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
+    *   .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute
+    *   window .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs
+    *   containing `MY_LOG_MESSAGE` are detected .withLogMessageThreshold("MY_LOG_MESSAGE", 2, alertingPlatform = AlertingPlatform.Grafan) // Raise an
+    *   alert through Grafana when a service generates two or more logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe. }
+    */
   def withLogMessageThreshold(message: String,
                               threshold: Int,
                               lessThanMode: Boolean = false,
@@ -326,30 +289,30 @@ case class AlertConfigBuilder(
                               alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
-  /**
-   * This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
-   *
-   * @param averageCPUThreshold The average percentage CPU used by all instances of your microservice
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
+    *
+    * @param averageCPUThreshold
+    *   The average percentage CPU used by all instances of your microservice
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
+    *   } </pre>
+    */
   def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(averageCPUThreshold = AverageCPUThreshold(averageCPUThreshold, alertingPlatform = alertingPlatform))
 
-  /**
-   * In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service.
-   * However, since platform services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to your configBuilder.
-   *
-   * @deprecated Custom alerting coming soon!
-   * @param platformService True if you are defining alerts for something that is NOT a standard microservice
-   * @return
-   */
+  /** In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service. However, since platform
+    * services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to
+    * your configBuilder.
+    *
+    * @deprecated
+    *   Custom alerting coming soon!
+    * @param platformService
+    *   True if you are defining alerts for something that is NOT a standard microservice
+    * @return
+    */
   def isPlatformService(platformService: Boolean): AlertConfigBuilder =
     this.copy(platformService = platformService)
 
@@ -364,97 +327,115 @@ case class AlertConfigBuilder(
 
     val currentEnvironment = Environment.get(System.getenv().getOrDefault("ENVIRONMENT", "production"))
 
-
     getAppConfigFileForService(serviceName, platformService).flatMap { file =>
-        val serviceDomain = getZone(serviceName, file, platformService)
+      val serviceDomain = getZone(serviceName, file, platformService)
 
-        def printSeq[A](a: Seq[A])(implicit writer: JsonFormat[A]): String =
-          a.toJson.compactPrint
+      def printSeq[A](a: Seq[A])(implicit writer: JsonFormat[A]): String =
+        a.toJson.compactPrint
 
-        ZoneToServiceDomainMapper.getServiceDomain(serviceDomain, platformService).map { serviceDomain =>
-          val updated5xxPercentThreshold = if (isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold)) {
+      ZoneToServiceDomainMapper.getServiceDomain(serviceDomain, platformService).map { serviceDomain =>
+        val updated5xxPercentThreshold =
+          if (isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold)) {
             333.33
           } else {
             http5xxPercentThreshold.percentage
           }
 
-          val updated5xxThreshold = if (isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold)) {
-            // if this alert is configured to use NOT Sensu, then set it to an unreasonably high threshold so
-            // it will never be triggered
-            Int.MaxValue
-          } else {
-            http5xxThreshold.count
-          }
+        val updated5xxThreshold = if (isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold)) {
+          // if this alert is configured to use NOT Sensu, then set it to an unreasonably high threshold so
+          // it will never be triggered
+          Int.MaxValue
+        } else {
+          http5xxThreshold.count
+        }
 
-          val updatedAverageCPUThreshold = if (isGrafanaEnabled(averageCPUThreshold.alertingPlatform, currentEnvironment, AlertType.AverageCPUThreshold)) {
+        val updatedAverageCPUThreshold =
+          if (isGrafanaEnabled(averageCPUThreshold.alertingPlatform, currentEnvironment, AlertType.AverageCPUThreshold)) {
             Int.MaxValue
           } else {
             averageCPUThreshold.count
           }
 
-          val updatedContainerKillThreshold = if (isGrafanaEnabled(containerKillThreshold.alertingPlatform, currentEnvironment, AlertType.ContainerKillThreshold)) {
+        val updatedContainerKillThreshold =
+          if (isGrafanaEnabled(containerKillThreshold.alertingPlatform, currentEnvironment, AlertType.ContainerKillThreshold)) {
             Int.MaxValue
           } else {
             containerKillThreshold.count
           }
 
-          val updatedErrorsLoggedThreshold = if (isGrafanaEnabled(errorsLoggedThreshold.alertingPlatform, currentEnvironment, AlertType.ErrorsLoggedThreshold)) {
+        val updatedErrorsLoggedThreshold =
+          if (isGrafanaEnabled(errorsLoggedThreshold.alertingPlatform, currentEnvironment, AlertType.ErrorsLoggedThreshold)) {
             Int.MaxValue
           } else {
             errorsLoggedThreshold.count
           }
 
-          val updatedExceptionThreshold = if (isGrafanaEnabled(exceptionThreshold.alertingPlatform, currentEnvironment, AlertType.ExceptionThreshold)) {
-            // if this alert is configured to use NOT Sensu, then set it to an unreasonably high threshold so
-            // it will never be triggered
-            Int.MaxValue
-          } else {
-            exceptionThreshold.count
-          }
+        val updatedExceptionThreshold = if (isGrafanaEnabled(exceptionThreshold.alertingPlatform, currentEnvironment, AlertType.ExceptionThreshold)) {
+          // if this alert is configured to use NOT Sensu, then set it to an unreasonably high threshold so
+          // it will never be triggered
+          Int.MaxValue
+        } else {
+          exceptionThreshold.count
+        }
 
-          val updatedTotalHttpRequestThreshold = if (isGrafanaEnabled(totalHttpRequestThreshold.alertingPlatform, currentEnvironment, AlertType.TotalHttpRequestThreshold)) {
+        val updatedTotalHttpRequestThreshold =
+          if (isGrafanaEnabled(totalHttpRequestThreshold.alertingPlatform, currentEnvironment, AlertType.TotalHttpRequestThreshold)) {
             Int.MaxValue
           } else {
             totalHttpRequestThreshold.count
           }
 
-          s"""
+        s"""
              |{
              |"app": "$serviceName.$serviceDomain",
              |"handlers": ${integrations.toJson.compactPrint},
              |"errors-logged-threshold":$updatedErrorsLoggedThreshold,
              |"exception-threshold":${exceptionThreshold
-              .copy(count = updatedExceptionThreshold)
-              .toJson(ExceptionThresholdProtocol.thresholdFormat)
-              .compactPrint},
+            .copy(count = updatedExceptionThreshold)
+            .toJson(ExceptionThresholdProtocol.thresholdFormat)
+            .compactPrint},
              |"5xx-threshold":${http5xxThreshold
-              .copy(count = updated5xxThreshold)
-              .toJson(Http5xxThresholdProtocol.thresholdFormat)
-              .compactPrint},
+            .copy(count = updated5xxThreshold)
+            .toJson(Http5xxThresholdProtocol.thresholdFormat)
+            .compactPrint},
              |"5xx-percent-threshold":${http5xxPercentThreshold
-              .copy(percentage = updated5xxPercentThreshold)
-              .toJson(Http5xxPercentThresholdProtocol.thresholdFormat)
-              .compactPrint},
+            .copy(percentage = updated5xxPercentThreshold)
+            .toJson(Http5xxPercentThresholdProtocol.thresholdFormat)
+            .compactPrint},
              |"containerKillThreshold" : $updatedContainerKillThreshold,
              |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption
-              .map(_.toJson.compactPrint)
-              .getOrElse(JsNull)},
-             |"httpTrafficThresholds" : ${httpTrafficThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold)).toJson.compactPrint},
-             |"httpStatusThresholds" : ${httpStatusThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).toJson.compactPrint},
-             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).toJson.compactPrint},
-             |"metricsThresholds" : ${printSeq(metricsThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)))(
-              MetricsThresholdProtocol.thresholdFormat)},
+            .map(_.toJson.compactPrint)
+            .getOrElse(JsNull)},
+             |"httpTrafficThresholds" : ${httpTrafficThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold))
+            .toJson
+            .compactPrint},
+             |"httpStatusThresholds" : ${httpStatusThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold))
+            .toJson
+            .compactPrint},
+             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold))
+            .toJson
+            .compactPrint},
+             |"metricsThresholds" : ${printSeq(metricsThresholds.filterNot(a =>
+            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)))(MetricsThresholdProtocol.thresholdFormat)},
              |"total-http-request-threshold": $updatedTotalHttpRequestThreshold,
-             |"log-message-thresholds" : ${logMessageThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).toJson.compactPrint},
+             |"log-message-thresholds" : ${logMessageThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold))
+            .toJson
+            .compactPrint},
              |"average-cpu-threshold" : $updatedAverageCPUThreshold,
-             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
+             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a =>
+            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(
+            HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
              |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds)(
-              HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
+            HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
              |"absolute-percentage-split-downstream-hod-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamHodThresholds)(
-              HttpAbsolutePercentSplitDownstreamHodThresholdProtocol.thresholdFormat)}
+            HttpAbsolutePercentSplitDownstreamHodThresholdProtocol.thresholdFormat)}
              |}
               """.stripMargin
-        }
+      }
     }
   }
 
@@ -482,106 +463,96 @@ case class TeamAlertConfigBuilder(
     platformService: Boolean = false
 ) extends Builder[Seq[AlertConfigBuilder]] {
 
-  /**
-   * Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
-   * @param string The name of your pagerduty integration. This integration must already exist in PagerDuty;
-   *               alert-config will not create it for you.
-   */
+  /** Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
+    * @param string
+    *   The name of your pagerduty integration. This integration must already exist in PagerDuty; alert-config will not create it for you.
+    */
   def withIntegrations(integrations: String*) =
     this.copy(integrations = integrations)
 
-  /**
-   * This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
-   *
-   * @param errorsLoggedThreshold The number of logs at ERROR level that this alert will trigger on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
+    *
+    * @param errorsLoggedThreshold
+    *   The number of logs at ERROR level that this alert will trigger on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window } </pre>
+    */
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold, alertingPlatform))
 
-  /**
-   * This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
-   * @param count The number of exceptions thrown that this alert will trigger on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical)
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
+    * @param count
+    *   The number of exceptions thrown that this alert will trigger on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical) } </pre>
+    */
   def withExceptionThreshold(exceptionThreshold: Int,
                              severity: AlertSeverity = AlertSeverity.Critical,
                              alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity, alertingPlatform = alertingPlatform))
 
-  /**
-   * This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
-   *
-   * @param http5xxThreshold The number of all http responses with a 5xx status code to alert on
-   * @param severity Whether to raise the alert as critical or warning
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window
-   * .withHttp5xxThreshold(5, AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+    *
+    * @param http5xxThreshold
+    *   The number of all http responses with a 5xx status code to alert on
+    * @param severity
+    *   Whether to raise the alert as critical or warning
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window .withHttp5xxThreshold(5,
+    *   AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window } </pre>
+    */
   def withHttp5xxThreshold(http5xxThreshold: Int,
                            severity: AlertSeverity = AlertSeverity.Critical,
                            alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity, alertingPlatform))
 
-  /**
-   * This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
-   *
-   * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
-   *
-   * @param percentThreshold The %age of requests that must be 5xx to trigger the alarm
-   * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in.
-   * Optional.  If you want to create a 5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method
-   * to use. You want to use this parameter if, for example, you don't want to alert on just a one-off 5xx in the middle of the night
-   * Defaults to 0, which would mean the parameter has no effect. Only applies in Grafana-based alerting, NOT supported on Sensu.
-   * @param severity How severe the alert is
-   * @param alertingPlatform Which platform to direct the alert to
-   * @return Configured threshold object
-   * @example
-   * <pre>
-   * {@code
-   * .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
-   * .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window
-   * .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
+    * window.
+    *
+    * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+    *
+    * @param percentThreshold
+    *   The %age of requests that must be 5xx to trigger the alarm
+    * @param minimumHttp5xxCountThreshold
+    *   The minimum count of 5xxs that must be present for the percentThreshold check to kick in. Optional. If you want to create a
+    *   5xxPercentThreshold alert but only if you have a given count of 5xxs, this is the method to use. You want to use this parameter if, for
+    *   example, you don't want to alert on just a one-off 5xx in the middle of the night Defaults to 0, which would mean the parameter has no effect.
+    *   Only applies in Grafana-based alerting, NOT supported on Sensu.
+    * @param severity
+    *   How severe the alert is
+    * @param alertingPlatform
+    *   Which platform to direct the alert to
+    * @return
+    *   Configured threshold object
+    * @example
+    *   <pre> {@code .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
+    *   .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a
+    *   15-minute window .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx
+    *   status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window } </pre>
+    */
   def withHttp5xxPercentThreshold(percentThreshold: Double,
                                   minimumHttp5xxCountThreshold: Int = 0,
                                   severity: AlertSeverity = AlertSeverity.Critical,
                                   alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity, alertingPlatform))
 
-  /**
-   * This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
-   * @param threshold Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000), timePeriod = 7))
-   * }
-   * </pre>
-   */
+  /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
+    * @param threshold
+    *   Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
+    * @return
+    * @example
+    *   <pre> {@code .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000),
+    *   timePeriod = 7)) } </pre>
+    */
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
@@ -594,16 +565,11 @@ case class TeamAlertConfigBuilder(
     }
   }
 
-  /**
-   * @param threshold
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499"))
-   * }
-   * </pre>
-   */
+  /** @param threshold
+    * @return
+    * @example
+    *   <pre> {@code .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499")) } </pre>
+    */
   def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) =
     this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 
@@ -613,38 +579,33 @@ case class TeamAlertConfigBuilder(
   def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold) =
     this.copy(httpAbsolutePercentSplitDownstreamHodThresholds = httpAbsolutePercentSplitDownstreamHodThresholds :+ threshold)
 
-  /**
-   * All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed with an out-of-memory exception.
-   * This alert will notify when a specified number of containers are killed within a 15-minute window.
-   *
-   * @param containerCrashThreshold The number of container kills to alert on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * <pre>
-   * {@code
-   * .withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed
+    * with an out-of-memory exception. This alert will notify when a specified number of containers are killed within a 15-minute window.
+    *
+    * @param containerCrashThreshold
+    *   The number of container kills to alert on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    *   <pre> {@code .withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute
+    *   window } </pre>
+    */
   def withContainerKillThreshold(containerKillThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(containerKillThreshold = ContainerKillThreshold(containerKillThreshold, alertingPlatform))
 
-  /**
-   * This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
-   *
-   * One or both of warning and critical must be given.
-   *
-   * @param threshold
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
-   * }
-   */
+  /** This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
+    *
+    * One or both of warning and critical must be given.
+    *
+    * @param threshold
+    * @return
+    * @example
+    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
+    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
+    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
+    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window }
+    */
   def withHttpTrafficThreshold(threshold: HttpTrafficThreshold) = {
     if (httpTrafficThresholds.nonEmpty) {
       throw new Exception("withHttpTrafficThreshold has already been defined for this microservice")
@@ -653,86 +614,77 @@ case class TeamAlertConfigBuilder(
     }
   }
 
-  /**
-   * This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within a 15-minute window.
-   * @param threshold Object with fields httpStatus, count, severity and httpMethod
-   * @return
-   *
-   * @example
-   * <pre>
-   * {@code
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status code 502 in a 15-minute window
-   * .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within
+    * a 15-minute window.
+    * @param threshold
+    *   Object with fields httpStatus, count, severity and httpMethod
+    * @return
+    *
+    * @example
+    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
+    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
+    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
+    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window } </pre>
+    */
   def withHttpStatusThreshold(threshold: HttpStatusThreshold) =
     this.copy(httpStatusThresholds = httpStatusThresholds :+ threshold)
 
-  /**
-   * This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
-   *
-   * @param threshold
-   * @return
-   * <pre>
-   * {@code
-   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status code 404 in a 15-minute window
-   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all requests return status code 500 in a 15-minute window
-   * .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0, AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
+    *
+    * @param threshold
+    * @return
+    *   <pre> {@code .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status
+    *   code 404 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all
+    *   requests return status code 500 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0,
+    *   AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window }
+    *   </pre>
+    */
   def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
-  /**
-   * This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
-   *
-   * @param threshold
-   * @return
-   * <pre>
-   * {@code
-   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_audit", query = "sumSeries(play.address-lookup.ecs*.audit.failure.count)", warning = Some(4), critical = Some(6)))
-   * .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_reject_audit", query = "integral(sumSeries(play.address-lookup.ecs*.audit.{failure,reject}.count))", critical = Some(10)))
-   * }
-   * </pre>
-   */
+  /** This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
+    *
+    * @param threshold
+    * @return
+    *   <pre> {@code .withMetricsThreshold(MetricsThreshold(name = "address_lookup_failed_audit", query =
+    *   "sumSeries(play.address-lookup.ecs*.audit.failure.count)", warning = Some(4), critical = Some(6))) .withMetricsThreshold(MetricsThreshold(name
+    *   \= "address_lookup_failed_reject_audit", query = "integral(sumSeries(play.address-lookup.ecs*.audit.{failure,reject}.count))", critical =
+    *   Some(10))) } </pre>
+    */
   def withMetricsThreshold(threshold: MetricsThreshold) =
     this.copy(metricsThresholds = metricsThresholds :+ threshold)
 
-  /**
-   * This alert will notify when your microservice receives a given number of requests within a 15-minute window.
-   *
-   * @param threshold The number of all http requests to alert on
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * <pre>
-   * {@code
-   * .withTotalHttpRequestsCountThreshold(1000) # alert when 1000 requests are received in a 15-minute window
-   * }
-   * </pre>
-   */
+  /** This alert will notify when your microservice receives a given number of requests within a 15-minute window.
+    *
+    * @param threshold
+    *   The number of all http requests to alert on
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    *   <pre> {@code .withTotalHttpRequestsCountThreshold(1000) # alert when 1000 requests are received in a 15-minute window } </pre>
+    */
   def withTotalHttpRequestsCountThreshold(threshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold, alertingPlatform))
 
-  /**
-   * This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
-   * @param message The substring to search for in the log message
-   * @param threshold The threshold above which an alert will be raised
-   * @param lessThanMode Flips the logic so that an alert is raised if less than the threshold amount is detected
-   * @param severity The severity to set for this check in PagerDuty
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * <pre>
-   * {@code
-   * .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
-   * .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute window
-   * .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs containing `MY_LOG_MESSAGE` are detected
-   * .withLogMessageThreshold("MY_LOG_MESSAGE", 2, alertingPlatform = AlertingPlatform.Grafan) // Raise an alert through Grafana when a service generates two or more logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe.
-   * }
-   */
+  /** This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
+    * @param message
+    *   The substring to search for in the log message
+    * @param threshold
+    *   The threshold above which an alert will be raised
+    * @param lessThanMode
+    *   Flips the logic so that an alert is raised if less than the threshold amount is detected
+    * @param severity
+    *   The severity to set for this check in PagerDuty
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    *   <pre> {@code .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
+    *   .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute
+    *   window .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs
+    *   containing `MY_LOG_MESSAGE` are detected .withLogMessageThreshold("MY_LOG_MESSAGE", 2, alertingPlatform = AlertingPlatform.Grafan) // Raise an
+    *   alert through Grafana when a service generates two or more logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe. }
+    */
   def withLogMessageThreshold(message: String,
                               threshold: Int,
                               lessThanMode: Boolean = false,
@@ -740,30 +692,30 @@ case class TeamAlertConfigBuilder(
                               alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity, alertingPlatform))
 
-  /**
-   * This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
-   *
-   * @param averageCPUThreshold The average percentage CPU used by all instances of your microservice
-   * @param alertingPlatform The that platform this alert should go to (Sensu or Grafana)
-   * @return
-   * @example
-   * <pre>
-   * {@code
-   * .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
-   * }
-   * </pre>
-   */
+  /** This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
+    *
+    * @param averageCPUThreshold
+    *   The average percentage CPU used by all instances of your microservice
+    * @param alertingPlatform
+    *   The that platform this alert should go to (Sensu or Grafana)
+    * @return
+    * @example
+    *   <pre> {@code .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
+    *   } </pre>
+    */
   def withAverageCPUThreshold(averageCPUThreshold: Int, alertingPlatform: AlertingPlatform = AlertingPlatform.Default) =
     this.copy(averageCPUThreshold = AverageCPUThreshold(averageCPUThreshold, alertingPlatform = alertingPlatform))
 
-  /**
-   * In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service.
-   * However, since platform services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to your configBuilder.
-   *
-   * @deprecated Custom alerting coming soon!
-   * @param platformService True if you are defining alerts for something that is NOT a standard microservice
-   * @return
-   */
+  /** In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service. However, since platform
+    * services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to
+    * your configBuilder.
+    *
+    * @deprecated
+    *   Custom alerting coming soon!
+    * @param platformService
+    *   True if you are defining alerts for something that is NOT a standard microservice
+    * @return
+    */
   def isPlatformService(platformService: Boolean): TeamAlertConfigBuilder =
     this.copy(platformService = platformService)
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertSeverity.scala
@@ -16,14 +16,12 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
-/**
- * An enumeration of sorts that encapsulates all the possible alert severities supported
- * by alert-config
- */
+/** An enumeration of sorts that encapsulates all the possible alert severities supported by alert-config
+  */
 sealed trait AlertSeverity
 
 object AlertSeverity {
-  object Info     extends AlertSeverity { override def toString: String = "info"  }
+  object Info     extends AlertSeverity { override def toString: String = "info"     }
   object Warning  extends AlertSeverity { override def toString: String = "warning"  }
   object Critical extends AlertSeverity { override def toString: String = "critical" }
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertingPlatform.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertingPlatform.scala
@@ -18,30 +18,26 @@ package uk.gov.hmrc.alertconfig.builder
 
 sealed trait AlertingPlatform
 
-/**
- * Configuration object to select an alerting platform
- * Defaults can be seen in GrafanaMigration
- * @see GrafanaMigration.scala
- */
+/** Configuration object to select an alerting platform Defaults can be seen in GrafanaMigration
+  * @see
+  *   GrafanaMigration.scala
+  */
 object AlertingPlatform {
 
-  /**
-   * Specifies the default alerting platform
-   */
+  /** Specifies the default alerting platform
+    */
   object Default extends AlertingPlatform {
     override def toString: String = "Default"
   }
 
-  /**
-   * Specifies the alerting platform to be Grafana
-   */
+  /** Specifies the alerting platform to be Grafana
+    */
   object Grafana extends AlertingPlatform {
     override def toString: String = "Grafana"
   }
 
-  /**
-   * Specifies the alerting platform to be Sensu
-   */
+  /** Specifies the alerting platform to be Sensu
+    */
   object Sensu extends AlertingPlatform {
     override def toString: String = "Sensu"
   }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AppConfigValidator.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AppConfigValidator.scala
@@ -22,14 +22,13 @@ import java.io.{File, FileInputStream, FileNotFoundException}
 import scala.util.{Failure, Success, Try}
 import scala.jdk.CollectionConverters._
 
-
 object AppConfigValidator {
   val logger = new Logger()
 
   def getAppConfigFileForService(serviceName: String, platformService: Boolean): Option[File] = {
-    val appConfigPath = System.getProperty("app-config-path", "../app-config")
+    val appConfigPath      = System.getProperty("app-config-path", "../app-config")
     val appConfigDirectory = new File(appConfigPath)
-    val appConfigFile = new File(appConfigDirectory, s"${serviceName}.yaml")
+    val appConfigFile      = new File(appConfigDirectory, s"${serviceName}.yaml")
 
     if (!appConfigDirectory.exists)
       throw new FileNotFoundException(s"Could not find app-config repository: $appConfigPath")
@@ -51,7 +50,7 @@ object AppConfigValidator {
       case None       => false
     }
 
-  def getZone(serviceName:String, appConfigFile: File, platformService: Boolean = false): Option[String] =
+  def getZone(serviceName: String, appConfigFile: File, platformService: Boolean = false): Option[String] =
     if (platformService)
       None
     else {
@@ -68,4 +67,5 @@ object AppConfigValidator {
           versionObject.get("zone")
       }
     }
+
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AverageCPUThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AverageCPUThreshold.scala
@@ -16,11 +16,12 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
-/**
- * This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
- * @param count The average percentage CPU used by all instances of your microservice
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
+  * @param count
+  *   The average percentage CPU used by all instances of your microservice
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class AverageCPUThreshold(
     count: Int = Int.MaxValue,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
@@ -16,13 +16,14 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
-/**
- * All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed with an out-of-memory exception.
- * This alert will notify when a specified number of containers are killed within a 15-minute window.
- *
- * @param count The number of container kills to alert on
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed with
+  * an out-of-memory exception. This alert will notify when a specified number of containers are killed within a 15-minute window.
+  *
+  * @param count
+  *   The number of container kills to alert on
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class ContainerKillThreshold(
     count: Int = Int.MaxValue,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -54,6 +54,7 @@ object Environment {
       case "production"   => Production
     }
   }
+
 }
 
 object AllEnvironmentAlertConfigBuilder {
@@ -192,11 +193,14 @@ case class EnvironmentAlertBuilder(
       JsString("/etc/sensu/handlers/noop.rb")
 
   private def severitiesFor(environment: Environment) =
-    JsArray(enabledEnvironments.getOrElse(environment, defaultSeverities)
-      // Temporary filter as part of TEL-4408 to ensure that info level
-      // notifications can't be enabled. They are only added to specific YAML
-      // files. Yes this is a hack, and when Sensu is gone, it can go too!
-      .filter(s => !s.toString.equalsIgnoreCase("info"))
-      .map(s => JsString(s.toString)).toVector)
+    JsArray(
+      enabledEnvironments
+        .getOrElse(environment, defaultSeverities)
+        // Temporary filter as part of TEL-4408 to ensure that info level
+        // notifications can't be enabled. They are only added to specific YAML
+        // files. Yes this is a hack, and when Sensu is gone, it can go too!
+        .filter(s => !s.toString.equalsIgnoreCase("info"))
+        .map(s => JsString(s.toString))
+        .toVector)
 
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
@@ -18,12 +18,14 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- *This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
- * @param count The number of exceptions thrown that this alert will trigger on
- * @param severity Whether to raise the alert as critical or warning
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
+  * @param count
+  *   The number of exceptions thrown that this alert will trigger on
+  * @param severity
+  *   Whether to raise the alert as critical or warning
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class ExceptionThreshold(
     count: Int = 2,
     severity: AlertSeverity = AlertSeverity.Critical,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -16,169 +16,163 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
-
 sealed trait AlertType
 
 object AlertType {
 
-  object AverageCPUThreshold extends AlertType
-  object ContainerKillThreshold extends AlertType
-  object ErrorsLoggedThreshold extends AlertType
-  object ExceptionThreshold extends AlertType
-  object Http5xxPercentThreshold extends AlertType
-  object Http5xxThreshold extends AlertType
-  object HttpAbsolutePercentSplitThreshold extends AlertType
-  object HttpStatusPercentThreshold extends AlertType
-  object HttpStatusThreshold extends AlertType
-  object HttpTrafficThreshold extends AlertType
-  object LogMessageThreshold extends AlertType
-  object MetricsThreshold extends AlertType
-  object TotalHttpRequestThreshold extends AlertType
+  object AverageCPUThreshold                   extends AlertType
+  object ContainerKillThreshold                extends AlertType
+  object ErrorsLoggedThreshold                 extends AlertType
+  object ExceptionThreshold                    extends AlertType
+  object Http5xxPercentThreshold               extends AlertType
+  object Http5xxThreshold                      extends AlertType
+  object HttpAbsolutePercentSplitThreshold     extends AlertType
+  object HttpStatusPercentThreshold            extends AlertType
+  object HttpStatusThreshold                   extends AlertType
+  object HttpTrafficThreshold                  extends AlertType
+  object LogMessageThreshold                   extends AlertType
+  object MetricsThreshold                      extends AlertType
+  object TotalHttpRequestThreshold             extends AlertType
   object Http90PercentileResponseTimeThreshold extends AlertType
 }
 
-/**
- * This class determines which standard alerts go where in each environment.
- *
- * This is so that the Telemetry team can safely migrate alerts gradually rather
- * than "big bang"ing them out
- */
+/** This class determines which standard alerts go where in each environment.
+  *
+  * This is so that the Telemetry team can safely migrate alerts gradually rather than "big bang"ing them out
+  */
 object GrafanaMigration {
 
   val config = Map(
     Environment.Integration -> Map(
-      AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
-
     Environment.Development -> Map(
-      AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
-
     Environment.Qa -> Map(
-      AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
-
     Environment.Staging -> Map(
-      AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     ),
-
     Environment.ExternalTest -> Map(
-      AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Sensu,
+      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
     ),
-
     Environment.Production -> Map(
-      AlertType.AverageCPUThreshold -> AlertingPlatform.Sensu,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Sensu,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Sensu,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Sensu,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
-      AlertType.Http5xxThreshold -> AlertingPlatform.Sensu,
-      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Sensu,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Sensu,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Sensu,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Sensu,
-      AlertType.MetricsThreshold -> AlertingPlatform.Sensu,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Sensu,
+      AlertType.ContainerKillThreshold                -> AlertingPlatform.Sensu,
+      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Sensu,
+      AlertType.ExceptionThreshold                    -> AlertingPlatform.Sensu,
+      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
+      AlertType.Http5xxThreshold                      -> AlertingPlatform.Sensu,
+      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Sensu,
+      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Sensu,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Sensu,
+      AlertType.LogMessageThreshold                   -> AlertingPlatform.Sensu,
+      AlertType.MetricsThreshold                      -> AlertingPlatform.Sensu,
+      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Sensu
     ),
-
     Environment.Management -> Map(
-      AlertType.AverageCPUThreshold -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold -> AlertingPlatform.Grafana,
+      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
       AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
     )
   )
 
-  /**
-   *
-   * @param alertingPlatform Alerting platform to test for Grafana being enabled
-   * @param currentEnvironment env to test for Grafana being enabled
-   * @param alertType alert type to test for Grafana being enabled
-   * @return True if the alerting platform matches the data { alertingPlatform, currentEnvironment, alertType }.
-   *         All 3 must be matches for the stated alert in the stated env at the states severity to be Grafana-ised.
-   */
+  /** @param alertingPlatform
+    *   Alerting platform to test for Grafana being enabled
+    * @param currentEnvironment
+    *   env to test for Grafana being enabled
+    * @param alertType
+    *   alert type to test for Grafana being enabled
+    * @return
+    *   True if the alerting platform matches the data { alertingPlatform, currentEnvironment, alertType }. All 3 must be matches for the stated alert
+    *   in the stated env at the states severity to be Grafana-ised.
+    */
   def isGrafanaEnabled(alertingPlatform: AlertingPlatform, currentEnvironment: Environment, alertType: AlertType): Boolean = {
     alertingPlatform match {
-      case AlertingPlatform.Sensu => false
+      case AlertingPlatform.Sensu   => false
       case AlertingPlatform.Grafana => true
-      case _ => config(currentEnvironment)(alertType) == AlertingPlatform.Grafana
+      case _                        => config(currentEnvironment)(alertType) == AlertingPlatform.Grafana
     }
   }
+
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -18,16 +18,20 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- * This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
- *
- * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
- *
- * @param percentage The percentage of all http responses with a 5xx status code to alert on
- * @param minimumHttp5xxCountThreshold The minimum count of 5xxs that must be present for the percentThreshold check to kick in. Useful if, for example, you don't want to alert on just a one-off 5xx in the middle of the night. Only supported on Grafana-based alerts.
- * @param severity Whether to raise the alert as critical or warning
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+  *
+  * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+  *
+  * @param percentage
+  *   The percentage of all http responses with a 5xx status code to alert on
+  * @param minimumHttp5xxCountThreshold
+  *   The minimum count of 5xxs that must be present for the percentThreshold check to kick in. Useful if, for example, you don't want to alert on
+  *   just a one-off 5xx in the middle of the night. Only supported on Grafana-based alerts.
+  * @param severity
+  *   Whether to raise the alert as critical or warning
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class Http5xxPercentThreshold(
     percentage: Double = 100.0,
     minimumHttp5xxCountThreshold: Int = 0,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
@@ -18,12 +18,14 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- * This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
- * @param count The number of all http responses with a 5xx status code to alert on
- * @param severity Whether to raise the alert as critical or warning
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
+  * @param count
+  *   The number of all http responses with a 5xx status code to alert on
+  * @param severity
+  *   Whether to raise the alert as critical or warning
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class Http5xxThreshold(
     count: Int = Int.MaxValue,
     severity: AlertSeverity = AlertSeverity.Critical,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http90PercentileThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http90PercentileThreshold.scala
@@ -18,16 +18,19 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- * This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
- *
- * One or both of warning and critical must be given.
- *
- * @param warning The response time in millisecond above which a warning level alert will be raised
- * @param critical The response time in millisecond above which a critical level alert will be raised
- * @param timePeriod How far back to consider in minutes. Default is 15 minutes. Range: 1 - 15 (inclusive)
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
+  *
+  * One or both of warning and critical must be given.
+  *
+  * @param warning
+  *   The response time in millisecond above which a warning level alert will be raised
+  * @param critical
+  *   The response time in millisecond above which a critical level alert will be raised
+  * @param timePeriod
+  *   How far back to consider in minutes. Default is 15 minutes. Range: 1 - 15 (inclusive)
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class Http90PercentileResponseTimeThreshold(
     warning: Option[Int],
     critical: Option[Int],

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusPercentThreshold.scala
@@ -18,14 +18,18 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- * This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
- * @param httpStatus The http status code that this alert will trigger on (429, 499-504)
- * @param percentage The percentage of all http responses with the given status code to alert on
- * @param severity Whether to raise the alert as critical or warning
- * @param httpMethod The http method to filter all requests by (one of All, Post, Get, Put, Delete)
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
+  * @param httpStatus
+  *   The http status code that this alert will trigger on (429, 499-504)
+  * @param percentage
+  *   The percentage of all http responses with the given status code to alert on
+  * @param severity
+  *   Whether to raise the alert as critical or warning
+  * @param httpMethod
+  *   The http method to filter all requests by (one of All, Post, Get, Put, Delete)
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class HttpStatusPercentThreshold(
     httpStatus: HttpStatus.HTTP_STATUS,
     percentage: Double = 100.0,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpStatusThreshold.scala
@@ -18,14 +18,19 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- * This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within a 15-minute window.
- * @param httpStatus The http status code that this alert will trigger on (429, 499-504)
- * @param count The number of http responses with the given status code to alert on
- * @param severity Whether to raise the alert as critical or warning
- * @param httpMethod The http method to filter all requests by (one of All, Post, Get, Put, Delete)
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within a
+  * 15-minute window.
+  * @param httpStatus
+  *   The http status code that this alert will trigger on (429, 499-504)
+  * @param count
+  *   The number of http responses with the given status code to alert on
+  * @param severity
+  *   Whether to raise the alert as critical or warning
+  * @param httpMethod
+  *   The http method to filter all requests by (one of All, Post, Get, Put, Delete)
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class HttpStatusThreshold(
     httpStatus: HttpStatus.HTTP_STATUS,
     count: Int = 1,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpTrafficThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpTrafficThreshold.scala
@@ -18,16 +18,19 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- * This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
- *
- * One or both of warning and critical must be given.
- *
- * @param warning The number of http requests below which a warning level alert will be raised
- * @param critical The number of http requests below which a critical level alert will be raised
- * @param maxMinutesBelowThreshold The number of minutes over which the threshold breaching triggers an alert
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
+  *
+  * One or both of warning and critical must be given.
+  *
+  * @param warning
+  *   The number of http requests below which a warning level alert will be raised
+  * @param critical
+  *   The number of http requests below which a critical level alert will be raised
+  * @param maxMinutesBelowThreshold
+  *   The number of minutes over which the threshold breaching triggers an alert
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class HttpTrafficThreshold(
     warning: Option[Int],
     critical: Option[Int],

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/LogMessageThreshold.scala
@@ -18,17 +18,21 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, JsonFormat}
 
-/**
- * This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
- *
- * By default we alert if the count of messages is >= threshold. If lessThanMode is set we alert if < threshold
- *
- * @param message The substring to search for in the log message
- * @param count The threshold above which an alert will be raised
- * @param lessThanMode If true, flips the logic so that an alert is raised if less than the threshold amount is detected
- * @param severity The severity to set for this check in PagerDuty
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
+  *
+  * By default we alert if the count of messages is >= threshold. If lessThanMode is set we alert if < threshold
+  *
+  * @param message
+  *   The substring to search for in the log message
+  * @param count
+  *   The threshold above which an alert will be raised
+  * @param lessThanMode
+  *   If true, flips the logic so that an alert is raised if less than the threshold amount is detected
+  * @param severity
+  *   The severity to set for this check in PagerDuty
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class LogMessageThreshold(
     message: String,
     count: Int,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/MetricsThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/MetricsThreshold.scala
@@ -18,18 +18,23 @@ package uk.gov.hmrc.alertconfig.builder
 
 import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
-/**
- * This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
- *
- * One or both of warning and critical must be given.
- *
- * @param name A unique name to give this alert, which will be used as the name of the alert in PagerDuty
- * @param query The metric path to use to trigger this alert
- * @param warning The response time in millisecond above which a warning level alert will be raised
- * @param critical The response time in millisecond above which a critical level alert will be raised
- * @param invert Set to true to invert the threshold (trigger on below instead of above)
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when a given metric query exceeds a given threshold within a 15-minute window.
+  *
+  * One or both of warning and critical must be given.
+  *
+  * @param name
+  *   A unique name to give this alert, which will be used as the name of the alert in PagerDuty
+  * @param query
+  *   The metric path to use to trigger this alert
+  * @param warning
+  *   The response time in millisecond above which a warning level alert will be raised
+  * @param critical
+  *   The response time in millisecond above which a critical level alert will be raised
+  * @param invert
+  *   Set to true to invert the threshold (trigger on below instead of above)
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class MetricsThreshold(
     name: String,
     query: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
@@ -16,12 +16,13 @@
 
 package uk.gov.hmrc.alertconfig.builder
 
-/**
- * This alert will notify when your microservice receives a given number of requests within a 15-minute window.
- *
- * @param count The number of all http requests to alert on
- * @param alertingPlatform The platform this alert will target. We are migrating towards Grafana and away from Sensu
- */
+/** This alert will notify when your microservice receives a given number of requests within a 15-minute window.
+  *
+  * @param count
+  *   The number of all http requests to alert on
+  * @param alertingPlatform
+  *   The platform this alert will target. We are migrating towards Grafana and away from Sensu
+  */
 case class TotalHttpRequestThreshold(
     count: Int = Int.MaxValue,
     alertingPlatform: AlertingPlatform = AlertingPlatform.Default

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CloudWatchSource.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CloudWatchSource.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.alertconfig.builder.custom
 object CloudWatchSource {
   type CloudWatchSource = String
 
-  val CLOUDWATCH = "CLOUDWATCH"
+  val CLOUDWATCH           = "CLOUDWATCH"
   val CLOUDWATCH_BUILD_LAB = "CLOUDWATCH_BUILD_LAB"
-  val CLOUDWATCH_CIP = "CLOUDWATCH_CIP"
+  val CLOUDWATCH_CIP       = "CLOUDWATCH_CIP"
   val CLOUDWATCH_TELEMETRY = "CLOUDWATCH_TELEMETRY"
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertSeverity.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertSeverity.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.alertconfig.builder.custom
 object CustomAlertSeverity {
   type AlertSeverity = String
 
-  val INFO = "info"
-  val WARNING = "warning"
+  val INFO     = "info"
+  val WARNING  = "warning"
   val CRITICAL = "critical"
 
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
@@ -21,39 +21,53 @@ import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
 import uk.gov.hmrc.alertconfig.builder.custom.ReducerFunction.ReducerFunction
 
-/**
- * CloudWatch metrics based alert.
- *
- * @param alertName        Name that the alert will be created with
- * @param cloudwatchSource Which CloudWatch Grafana datasource to use
- * @param dashboardPanelId Specific panel to deep link to that is specific to this alert
- * @param dashboardUri     Grafana uri to link to. This should just be the uri path and not include the domain
- * @param dimensions       Which CloudWatch dimensions to filter the metric on
- * @param integrations     Which PagerDuty integrations to direct this alert to
- * @param metricName       Which CloudWatch metric to filter the alert on
- * @param namespace        Which CloudWatch service namespace to filter the alert on
- * @param operator         Whether to evaluate the metric as greater than or less than
- * @param reducerFunction  Function to use when manipulate data returned from query
- * @param runbookUrl       Runbook for when this alert fires
- * @param severity         The severity of this alert. E.g. Warning or Critical
- * @param summary          The description to populate in PagerDuty when the alert fires
- * @param teamName         All alerts are prefixed with the team name
- * @param thresholds       Trigger point for each environment
- */
+/** CloudWatch metrics based alert.
+  *
+  * @param alertName
+  *   Name that the alert will be created with
+  * @param cloudwatchSource
+  *   Which CloudWatch Grafana datasource to use
+  * @param dashboardPanelId
+  *   Specific panel to deep link to that is specific to this alert
+  * @param dashboardUri
+  *   Grafana uri to link to. This should just be the uri path and not include the domain
+  * @param dimensions
+  *   Which CloudWatch dimensions to filter the metric on
+  * @param integrations
+  *   Which PagerDuty integrations to direct this alert to
+  * @param metricName
+  *   Which CloudWatch metric to filter the alert on
+  * @param namespace
+  *   Which CloudWatch service namespace to filter the alert on
+  * @param operator
+  *   Whether to evaluate the metric as greater than or less than
+  * @param reducerFunction
+  *   Function to use when manipulate data returned from query
+  * @param runbookUrl
+  *   Runbook for when this alert fires
+  * @param severity
+  *   The severity of this alert. E.g. Warning or Critical
+  * @param summary
+  *   The description to populate in PagerDuty when the alert fires
+  * @param teamName
+  *   All alerts are prefixed with the team name
+  * @param thresholds
+  *   Trigger point for each environment
+  */
 case class CustomCloudWatchMetricAlert(
-                                        alertName: String,
-                                        cloudwatchSource: CloudWatchSource,
-                                        dashboardPanelId: Option[Int],
-                                        dashboardUri: Option[String],
-                                        dimensions: Map[String, String],
-                                        integrations: Seq[String],
-                                        metricName: String,
-                                        namespace: String,
-                                        operator: EvaluationOperator,
-                                        reducerFunction: Option[ReducerFunction] = Some(ReducerFunction.LAST),
-                                        runbookUrl: Option[String],
-                                        severity: AlertSeverity,
-                                        summary: String,
-                                        teamName: String,
-                                        thresholds: EnvironmentThresholds
-                                      ) extends CustomAlert
+    alertName: String,
+    cloudwatchSource: CloudWatchSource,
+    dashboardPanelId: Option[Int],
+    dashboardUri: Option[String],
+    dimensions: Map[String, String],
+    integrations: Seq[String],
+    metricName: String,
+    namespace: String,
+    operator: EvaluationOperator,
+    reducerFunction: Option[ReducerFunction] = Some(ReducerFunction.LAST),
+    runbookUrl: Option[String],
+    severity: AlertSeverity,
+    summary: String,
+    teamName: String,
+    thresholds: EnvironmentThresholds
+) extends CustomAlert

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomLogAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomLogAlert.scala
@@ -19,27 +19,31 @@ package uk.gov.hmrc.alertconfig.builder.custom
 import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
 
-
 // This specific alert type is here to allow us to figure out how different types of
 // custom alerts will work. This one isn't as well defined as the Metrics one so will
 // need extending at some point.
 
-/**
- * Generate custom alerts that are based on logs in Elasticsearch.
- *
- * @param alertName    Name that the alert will be created with
- * @param logMessage   The exact string that you are searching for
- * @param severity     The severity of this alert.
- * @param teamName     All alerts are prefixed with the team name
- * @param thresholds   Trigger point for each environment
- * @param integrations Which PagerDuty integrations to direct this alert to
- */
+/** Generate custom alerts that are based on logs in Elasticsearch.
+  *
+  * @param alertName
+  *   Name that the alert will be created with
+  * @param logMessage
+  *   The exact string that you are searching for
+  * @param severity
+  *   The severity of this alert.
+  * @param teamName
+  *   All alerts are prefixed with the team name
+  * @param thresholds
+  *   Trigger point for each environment
+  * @param integrations
+  *   Which PagerDuty integrations to direct this alert to
+  */
 case class CustomLogAlert(
-                           alertName: String,
-                           logMessage: String,
-                           operator: EvaluationOperator,
-                           severity: AlertSeverity,
-                           teamName: String,
-                           thresholds: EnvironmentThresholds,
-                           integrations: Seq[String]
-                         ) extends CustomAlert
+    alertName: String,
+    logMessage: String,
+    operator: EvaluationOperator,
+    severity: AlertSeverity,
+    teamName: String,
+    thresholds: EnvironmentThresholds,
+    integrations: Seq[String]
+) extends CustomAlert

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomMetricAlert.scala
@@ -20,33 +20,44 @@ import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
 import uk.gov.hmrc.alertconfig.builder.custom.ReducerFunction.ReducerFunction
 
-/**
- * Graphite metric based alert.
- *
- * @param alertName        Name that the alert will be created with
- * @param dashboardUri     Grafana uri to link to. This should just be the uri path and not include the domain
- * @param dashboardPanelId Specific panel to deep link to that is specific to this alert
- * @param integrations     Which PagerDuty integrations to direct this alert to
- * @param operator         Whether to evaluate the metric as greater than or less than
- * @param query            Graphite query you're running
- * @param teamName         All alerts are prefixed with the team name
- * @param reducerFunction  Function to use when manipulate data returned from query
- * @param runbookUrl       Runbook for when this alert fires
- * @param severity         The severity of this alert. E.g. Warning or Critical
- * @param summary          The description to populate in PagerDuty when the alert fires
- * @param thresholds       Trigger point for each environment
- */
+/** Graphite metric based alert.
+  *
+  * @param alertName
+  *   Name that the alert will be created with
+  * @param dashboardUri
+  *   Grafana uri to link to. This should just be the uri path and not include the domain
+  * @param dashboardPanelId
+  *   Specific panel to deep link to that is specific to this alert
+  * @param integrations
+  *   Which PagerDuty integrations to direct this alert to
+  * @param operator
+  *   Whether to evaluate the metric as greater than or less than
+  * @param query
+  *   Graphite query you're running
+  * @param teamName
+  *   All alerts are prefixed with the team name
+  * @param reducerFunction
+  *   Function to use when manipulate data returned from query
+  * @param runbookUrl
+  *   Runbook for when this alert fires
+  * @param severity
+  *   The severity of this alert. E.g. Warning or Critical
+  * @param summary
+  *   The description to populate in PagerDuty when the alert fires
+  * @param thresholds
+  *   Trigger point for each environment
+  */
 case class CustomMetricAlert(
-                              alertName: String,
-                              dashboardUri: Option[String],
-                              dashboardPanelId: Option[Int],
-                              integrations: Seq[String],
-                              operator: EvaluationOperator,
-                              query: String,
-                              teamName: String,
-                              reducerFunction: Option[ReducerFunction] = Some(ReducerFunction.LAST),
-                              runbookUrl: Option[String],
-                              severity: AlertSeverity,
-                              summary: String,
-                              thresholds: EnvironmentThresholds,
-                            ) extends CustomAlert
+    alertName: String,
+    dashboardUri: Option[String],
+    dashboardPanelId: Option[Int],
+    integrations: Seq[String],
+    operator: EvaluationOperator,
+    query: String,
+    teamName: String,
+    reducerFunction: Option[ReducerFunction] = Some(ReducerFunction.LAST),
+    runbookUrl: Option[String],
+    severity: AlertSeverity,
+    summary: String,
+    thresholds: EnvironmentThresholds
+) extends CustomAlert

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
@@ -19,6 +19,21 @@ package uk.gov.hmrc.alertconfig.builder.custom
 import uk.gov.hmrc.alertconfig.builder.Environment
 
 /** Define thresholds for any environments you want this custom alert to be active in.
+  *
+  * @param development
+  *   The threshold for the development environment.
+  * @param externaltest
+  *   The threshold for the external test environment.
+  * @param integration
+  *   The threshold for the integration environment.
+  * @param management
+  *   The threshold for the management environment.
+  * @param production
+  *   The threshold for the production environment.
+  * @param qa
+  *   The threshold for the quality assurance environment.
+  * @param staging
+  *   The threshold for the staging environment.
   */
 case class EnvironmentThresholds(
     development: Option[Int] = None,
@@ -31,6 +46,11 @@ case class EnvironmentThresholds(
 ) {
 
   /** Checks if the given environment has a threshold defined.
+    *
+    * @param environment
+    *   The environment to check.
+    * @return
+    *   True if the threshold for the given environment is defined, otherwise false.
     */
   def isEnvironmentDefined(environment: Environment): Boolean = {
     environment match {
@@ -45,6 +65,11 @@ case class EnvironmentThresholds(
   }
 
   /** Removes the thresholds for all environments other than the one requested.
+    *
+    * @param environment
+    *   The environment to keep the threshold for.
+    * @return
+    *   EnvironmentThresholds with thresholds for only the specified environment.
     */
   def removeAllOtherEnvironmentThresholds(environment: Environment): EnvironmentThresholds = {
     environment match {
@@ -64,9 +89,12 @@ case class EnvironmentThresholds(
   */
 object EnvironmentThresholds {
 
-  /** @param threshold
-    *   An integer to be set as threshold for all seven environments
+  /** Creates EnvironmentThresholds with the same threshold for all environments.
+    *
+    * @param threshold
+    *   An integer to be set as the threshold for all seven environments.
     * @return
+    *   EnvironmentThresholds with the same threshold for all environments.
     */
   def forAllEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
@@ -78,18 +106,24 @@ object EnvironmentThresholds {
     management = Some(threshold)
   )
 
-  /** @param threshold
-    *   An integer to be set for externaltest and production environments
+  /** Creates EnvironmentThresholds with the same threshold for production and external test environments.
+    *
+    * @param threshold
+    *   An integer to be set for the production and external test environments.
     * @return
+    *   EnvironmentThresholds with the same threshold for production and external test environments.
     */
   def forAllPordEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
     externaltest = Some(threshold)
   )
 
-  /** @param threshold
-    *   An integer to be set as threshold for all non-production
+  /** Creates EnvironmentThresholds with the same threshold for all non-production environments.
+    *
+    * @param threshold
+    *   An integer to be set as the threshold for all non-production environments.
     * @return
+    *   EnvironmentThresholds with the same threshold for all non-production environments.
     */
   def forAllNonPordEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     staging = Some(threshold),

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
@@ -67,9 +67,35 @@ case class EnvironmentThresholds(
  * Set common threshold for all environments
  */
 object EnvironmentThresholds {
+
+  /**
+   * @param threshold An integer to be set as threshold for all seven environments
+   * @return
+   */
   def forAllEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
     externaltest = Some(threshold),
+    staging = Some(threshold),
+    qa = Some(threshold),
+    development = Some(threshold),
+    integration = Some(threshold),
+    management = Some(threshold)
+  )
+
+  /**
+   * @param threshold An integer to be set for externaltest and production environments
+   * @return
+   */
+  def forAllPordEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
+    production = Some(threshold),
+    externaltest = Some(threshold)
+  )
+
+  /**
+   * @param threshold An integer to be set as threshold for all non-production
+   * @return
+   */
+  def forAllNonPordEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     staging = Some(threshold),
     qa = Some(threshold),
     development = Some(threshold),

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
@@ -18,60 +18,56 @@ package uk.gov.hmrc.alertconfig.builder.custom
 
 import uk.gov.hmrc.alertconfig.builder.Environment
 
-/**
- * Define thresholds for any environments you want this custom
- * alert to be active in.
- */
+/** Define thresholds for any environments you want this custom alert to be active in.
+  */
 case class EnvironmentThresholds(
-                                  development: Option[Int] = None,
-                                  externaltest: Option[Int] = None,
-                                  integration: Option[Int] = None,
-                                  management: Option[Int] = None,
-                                  production: Option[Int] = None,
-                                  qa: Option[Int] = None,
-                                  staging: Option[Int] = None
-                                ) {
-  /**
-   * Checks if the given environment has a threshold defined.
-   */
+    development: Option[Int] = None,
+    externaltest: Option[Int] = None,
+    integration: Option[Int] = None,
+    management: Option[Int] = None,
+    production: Option[Int] = None,
+    qa: Option[Int] = None,
+    staging: Option[Int] = None
+) {
+
+  /** Checks if the given environment has a threshold defined.
+    */
   def isEnvironmentDefined(environment: Environment): Boolean = {
     environment match {
-      case Environment.Development => development.isDefined
+      case Environment.Development  => development.isDefined
       case Environment.ExternalTest => externaltest.isDefined
-      case Environment.Integration => integration.isDefined
-      case Environment.Management => management.isDefined
-      case Environment.Production => production.isDefined
-      case Environment.Qa => qa.isDefined
-      case Environment.Staging => staging.isDefined
+      case Environment.Integration  => integration.isDefined
+      case Environment.Management   => management.isDefined
+      case Environment.Production   => production.isDefined
+      case Environment.Qa           => qa.isDefined
+      case Environment.Staging      => staging.isDefined
     }
   }
 
-  /**
-   * Removes the thresholds for all environments other than the one requested.
-   */
+  /** Removes the thresholds for all environments other than the one requested.
+    */
   def removeAllOtherEnvironmentThresholds(environment: Environment): EnvironmentThresholds = {
     environment match {
-      case Environment.Development => EnvironmentThresholds(development = development)
+      case Environment.Development  => EnvironmentThresholds(development = development)
       case Environment.ExternalTest => EnvironmentThresholds(externaltest = externaltest)
-      case Environment.Integration => EnvironmentThresholds(integration = integration)
-      case Environment.Management => EnvironmentThresholds(management = management)
-      case Environment.Production => EnvironmentThresholds(production = production)
-      case Environment.Qa => EnvironmentThresholds(qa = qa)
-      case Environment.Staging => EnvironmentThresholds(staging = staging)
+      case Environment.Integration  => EnvironmentThresholds(integration = integration)
+      case Environment.Management   => EnvironmentThresholds(management = management)
+      case Environment.Production   => EnvironmentThresholds(production = production)
+      case Environment.Qa           => EnvironmentThresholds(qa = qa)
+      case Environment.Staging      => EnvironmentThresholds(staging = staging)
     }
   }
 
 }
 
-/**
- * Set common threshold for all environments
- */
+/** Set common threshold for all environments
+  */
 object EnvironmentThresholds {
 
-  /**
-   * @param threshold An integer to be set as threshold for all seven environments
-   * @return
-   */
+  /** @param threshold
+    *   An integer to be set as threshold for all seven environments
+    * @return
+    */
   def forAllEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
     externaltest = Some(threshold),
@@ -82,19 +78,19 @@ object EnvironmentThresholds {
     management = Some(threshold)
   )
 
-  /**
-   * @param threshold An integer to be set for externaltest and production environments
-   * @return
-   */
+  /** @param threshold
+    *   An integer to be set for externaltest and production environments
+    * @return
+    */
   def forAllPordEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
     externaltest = Some(threshold)
   )
 
-  /**
-   * @param threshold An integer to be set as threshold for all non-production
-   * @return
-   */
+  /** @param threshold
+    *   An integer to be set as threshold for all non-production
+    * @return
+    */
   def forAllNonPordEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
     staging = Some(threshold),
     qa = Some(threshold),
@@ -102,4 +98,5 @@ object EnvironmentThresholds {
     integration = Some(threshold),
     management = Some(threshold)
   )
+
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EvaluationOperator.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EvaluationOperator.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.alertconfig.builder.custom
 
-
 object EvaluationOperator {
   type EvaluationOperator = String
 
   val GREATER_THAN = "gt"
-  val LESS_THAN = "lt"
+  val LESS_THAN    = "lt"
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/ReducerFunction.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/ReducerFunction.scala
@@ -20,9 +20,9 @@ object ReducerFunction {
   type ReducerFunction = String
 
   val COUNT = "count"
-  val LAST = "last"
-  val MAX = "max"
-  val MEAN = "mean"
-  val MIN = "min"
-  val SUM = "sum"
+  val LAST  = "last"
+  val MAX   = "max"
+  val MEAN  = "mean"
+  val MIN   = "min"
+  val SUM   = "sum"
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -28,7 +28,7 @@ object AlertsYamlBuilder {
 
   def run(alertConfigs: Seq[AlertConfig], environment: String): Unit = {
     val currentEnvironment = Environment.get(environment)
-    val topLevelConfig = TopLevelConfig(convert(alertConfigs, currentEnvironment))
+    val topLevelConfig     = TopLevelConfig(convert(alertConfigs, currentEnvironment))
     logger.debug(s"Generating alert config YAML for $currentEnvironment")
 
     mapper.writeValue(new File(s"./target/output/services.yml"), topLevelConfig)
@@ -40,7 +40,7 @@ object AlertsYamlBuilder {
   }
 
   def convert(alertConfig: AlertConfig, currentEnvironment: Environment): Seq[ServiceConfig] = {
-    val filtered = alertConfig.environmentConfig.filter(_.enabledEnvironments.contains(currentEnvironment))
+    val filtered                 = alertConfig.environmentConfig.filter(_.enabledEnvironments.contains(currentEnvironment))
     val enabledIntegrationsInEnv = filtered.map(_.integrationName).toSet
     val integrationSeveritiesForEnv = filtered
       .map(builder => builder.integrationName -> builder.enabledEnvironments.getOrElse(currentEnvironment, Set()))
@@ -49,7 +49,10 @@ object AlertsYamlBuilder {
     alertConfig.alertConfig.flatMap(convert(_, enabledIntegrationsInEnv, currentEnvironment, integrationSeveritiesForEnv))
   }
 
-  def convert(alertConfigBuilder: AlertConfigBuilder, environmentDefinedIntegrations: Set[String], currentEnvironment: Environment, integrationSeveritiesForEnv: Map[String, Set[Severity]]): Option[ServiceConfig] = {
+  def convert(alertConfigBuilder: AlertConfigBuilder,
+              environmentDefinedIntegrations: Set[String],
+              currentEnvironment: Environment,
+              integrationSeveritiesForEnv: Map[String, Set[Severity]]): Option[ServiceConfig] = {
     val enabledIntegrations = alertConfigBuilder.integrations.toSet.intersect(environmentDefinedIntegrations)
     if (enabledIntegrations.isEmpty || !serviceDeployedInEnv(alertConfigBuilder.serviceName, alertConfigBuilder.platformService)) {
       None
@@ -57,8 +60,8 @@ object AlertsYamlBuilder {
       val finalAlertConfigBuilder = removeUnusedAlerts(alertConfigBuilder, integrationSeveritiesForEnv)
       Some(
         ServiceConfig(
-          service   = finalAlertConfigBuilder.serviceName.trim.toLowerCase.replaceAll(" ", "-"),
-          alerts    = convertAlerts(finalAlertConfigBuilder, currentEnvironment),
+          service = finalAlertConfigBuilder.serviceName.trim.toLowerCase.replaceAll(" ", "-"),
+          alerts = convertAlerts(finalAlertConfigBuilder, currentEnvironment),
           pagerduty = enabledIntegrations.map(integration => PagerDuty(integrationKeyName = integration)).toSeq
         ))
     }
@@ -66,31 +69,47 @@ object AlertsYamlBuilder {
 
   def removeUnusedAlerts(alertConfigBuilder: AlertConfigBuilder, integrationSeveritiesForEnv: Map[String, Set[Severity]]): AlertConfigBuilder = {
     val uniqueEnabledSeveritiesForServiceInEnv = integrationSeveritiesForEnv.values.flatten.toSet
-      if ( uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Critical) && !uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning)) {
-        removeUnusedAlerts(alertConfigBuilder, AlertSeverity.Warning)
-      } else if (
-        uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning) && !uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Critical)
-      ) {
-        removeUnusedAlerts(alertConfigBuilder, AlertSeverity.Critical)
-      } else {
-        alertConfigBuilder
-      }
+    if (uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Critical) && !uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning)) {
+      removeUnusedAlerts(alertConfigBuilder, AlertSeverity.Warning)
+    } else if (uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning) && !uniqueEnabledSeveritiesForServiceInEnv.contains(
+        Severity.Critical)) {
+      removeUnusedAlerts(alertConfigBuilder, AlertSeverity.Critical)
+    } else {
+      alertConfigBuilder
+    }
   }
 
   def removeUnusedAlerts(alertConfigBuilder: AlertConfigBuilder, severityToRemove: AlertSeverity): AlertConfigBuilder =
     alertConfigBuilder.copy(
-      exceptionThreshold                                  = if(alertConfigBuilder.exceptionThreshold.severity      == severityToRemove) ExceptionThreshold(count = Int.MaxValue)           else alertConfigBuilder.exceptionThreshold,
-      http5xxThreshold                                    = if(alertConfigBuilder.http5xxThreshold.severity        == severityToRemove) Http5xxThreshold(count = Int.MaxValue)             else alertConfigBuilder.http5xxThreshold,
-      http5xxPercentThreshold                             = if(alertConfigBuilder.http5xxPercentThreshold.severity == severityToRemove) Http5xxPercentThreshold(percentage = Int.MaxValue) else alertConfigBuilder.http5xxPercentThreshold,
-      http90PercentileResponseTimeThresholds              = alertConfigBuilder.http90PercentileResponseTimeThresholds             .map(threshold => if(severityToRemove == AlertSeverity.Warning) threshold.copy(warning = None) else if (severityToRemove == AlertSeverity.Critical) threshold.copy(critical = None) else threshold),
-      httpAbsolutePercentSplitThresholds                  = alertConfigBuilder.httpAbsolutePercentSplitThresholds                 .filterNot(_.severity == severityToRemove),
-      httpAbsolutePercentSplitDownstreamServiceThresholds = alertConfigBuilder.httpAbsolutePercentSplitDownstreamServiceThresholds.filterNot(_.severity == severityToRemove),
-      httpAbsolutePercentSplitDownstreamHodThresholds     = alertConfigBuilder.httpAbsolutePercentSplitDownstreamHodThresholds    .filterNot(_.severity == severityToRemove),
-      httpTrafficThresholds                               = alertConfigBuilder.httpTrafficThresholds                              .map(threshold => if(severityToRemove == AlertSeverity.Warning) threshold.copy(warning = None) else if (severityToRemove == AlertSeverity.Critical) threshold.copy(critical = None) else threshold),
-      httpStatusThresholds                                = alertConfigBuilder.httpStatusThresholds                               .filterNot(_.severity == severityToRemove),
-      httpStatusPercentThresholds                         = alertConfigBuilder.httpStatusPercentThresholds                        .filterNot(_.severity == severityToRemove),
-      metricsThresholds                                   = alertConfigBuilder.metricsThresholds                                  .map(threshold => if(severityToRemove == AlertSeverity.Warning) threshold.copy(warning = None) else if (severityToRemove == AlertSeverity.Critical) threshold.copy(critical = None) else threshold),
-      logMessageThresholds                                = alertConfigBuilder.logMessageThresholds                               .filterNot(_.severity == severityToRemove)
+      exceptionThreshold =
+        if (alertConfigBuilder.exceptionThreshold.severity == severityToRemove) ExceptionThreshold(count = Int.MaxValue)
+        else alertConfigBuilder.exceptionThreshold,
+      http5xxThreshold =
+        if (alertConfigBuilder.http5xxThreshold.severity == severityToRemove) Http5xxThreshold(count = Int.MaxValue)
+        else alertConfigBuilder.http5xxThreshold,
+      http5xxPercentThreshold =
+        if (alertConfigBuilder.http5xxPercentThreshold.severity == severityToRemove) Http5xxPercentThreshold(percentage = Int.MaxValue)
+        else alertConfigBuilder.http5xxPercentThreshold,
+      http90PercentileResponseTimeThresholds = alertConfigBuilder.http90PercentileResponseTimeThresholds.map(threshold =>
+        if (severityToRemove == AlertSeverity.Warning) threshold.copy(warning = None)
+        else if (severityToRemove == AlertSeverity.Critical) threshold.copy(critical = None)
+        else threshold),
+      httpAbsolutePercentSplitThresholds = alertConfigBuilder.httpAbsolutePercentSplitThresholds.filterNot(_.severity == severityToRemove),
+      httpAbsolutePercentSplitDownstreamServiceThresholds =
+        alertConfigBuilder.httpAbsolutePercentSplitDownstreamServiceThresholds.filterNot(_.severity == severityToRemove),
+      httpAbsolutePercentSplitDownstreamHodThresholds =
+        alertConfigBuilder.httpAbsolutePercentSplitDownstreamHodThresholds.filterNot(_.severity == severityToRemove),
+      httpTrafficThresholds = alertConfigBuilder.httpTrafficThresholds.map(threshold =>
+        if (severityToRemove == AlertSeverity.Warning) threshold.copy(warning = None)
+        else if (severityToRemove == AlertSeverity.Critical) threshold.copy(critical = None)
+        else threshold),
+      httpStatusThresholds = alertConfigBuilder.httpStatusThresholds.filterNot(_.severity == severityToRemove),
+      httpStatusPercentThresholds = alertConfigBuilder.httpStatusPercentThresholds.filterNot(_.severity == severityToRemove),
+      metricsThresholds = alertConfigBuilder.metricsThresholds.map(threshold =>
+        if (severityToRemove == AlertSeverity.Warning) threshold.copy(warning = None)
+        else if (severityToRemove == AlertSeverity.Critical) threshold.copy(critical = None)
+        else threshold),
+      logMessageThresholds = alertConfigBuilder.logMessageThresholds.filterNot(_.severity == severityToRemove)
     )
 
   def convertAlerts(alertConfigBuilder: AlertConfigBuilder, currentEnvironment: Environment): Alerts = {
@@ -101,37 +120,57 @@ object AlertsYamlBuilder {
       exceptionThreshold = convertExceptionThreshold(alertConfigBuilder.exceptionThreshold, currentEnvironment),
       http5xxPercentThreshold = convertHttp5xxPercentThresholds(alertConfigBuilder.http5xxPercentThreshold, currentEnvironment),
       http5xxThreshold = convertHttp5xxThreshold(alertConfigBuilder.http5xxThreshold, currentEnvironment),
-      httpAbsolutePercentSplitThreshold = convertHttpAbsolutePercentSplitThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitThresholds, currentEnvironment),
+      httpAbsolutePercentSplitThreshold =
+        convertHttpAbsolutePercentSplitThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitThresholds, currentEnvironment),
       httpStatusPercentThresholds = convertHttpStatusPercentThresholdAlerts(alertConfigBuilder.httpStatusPercentThresholds, currentEnvironment),
       httpStatusThresholds = convertHttpStatusThresholds(alertConfigBuilder.httpStatusThresholds, currentEnvironment),
       httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds, currentEnvironment),
       logMessageThresholds = convertLogMessageThresholdAlerts(alertConfigBuilder.logMessageThresholds, currentEnvironment),
       totalHttpRequestThreshold = convertTotalHttpRequestThreshold(alertConfigBuilder.totalHttpRequestThreshold, currentEnvironment),
       metricsThresholds = convertMetricsThreshold(alertConfigBuilder.metricsThresholds, currentEnvironment),
-      http90PercentileResponseTimeThreshold = convertHttp90PercentileResponseTimeThreshold(alertConfigBuilder.http90PercentileResponseTimeThresholds, currentEnvironment)
+      http90PercentileResponseTimeThreshold =
+        convertHttp90PercentileResponseTimeThreshold(alertConfigBuilder.http90PercentileResponseTimeThresholds, currentEnvironment)
     )
   }
 
   def convertAverageCPUThreshold(averageCPUThreshold: AverageCPUThreshold, currentEnvironment: Environment): Option[YamlAverageCPUThresholdAlert] = {
-    Option.when(isGrafanaEnabled(averageCPUThreshold.alertingPlatform, currentEnvironment, AlertType.AverageCPUThreshold) && averageCPUThreshold.count < Int.MaxValue)(
+    Option.when(
+      isGrafanaEnabled(
+        averageCPUThreshold.alertingPlatform,
+        currentEnvironment,
+        AlertType.AverageCPUThreshold) && averageCPUThreshold.count < Int.MaxValue)(
       YamlAverageCPUThresholdAlert(averageCPUThreshold.count)
     )
   }
 
-  def convertContainerKillThreshold(containerKillThreshold: ContainerKillThreshold, currentEnvironment: Environment): Option[YamlContainerKillThresholdAlert] = {
-    Option.when(isGrafanaEnabled(containerKillThreshold.alertingPlatform, currentEnvironment, AlertType.ContainerKillThreshold) && containerKillThreshold.count < Int.MaxValue)(
+  def convertContainerKillThreshold(containerKillThreshold: ContainerKillThreshold,
+                                    currentEnvironment: Environment): Option[YamlContainerKillThresholdAlert] = {
+    Option.when(
+      isGrafanaEnabled(
+        containerKillThreshold.alertingPlatform,
+        currentEnvironment,
+        AlertType.ContainerKillThreshold) && containerKillThreshold.count < Int.MaxValue)(
       YamlContainerKillThresholdAlert(containerKillThreshold.count)
     )
   }
 
-  def convertErrorsLoggedThreshold(errorsLoggedThreshold: ErrorsLoggedThreshold, currentEnvironment: Environment): Option[YamlErrorsLoggedThresholdAlert] = {
-    Option.when(isGrafanaEnabled(errorsLoggedThreshold.alertingPlatform, currentEnvironment, AlertType.ErrorsLoggedThreshold) && errorsLoggedThreshold.count < Int.MaxValue)(
+  def convertErrorsLoggedThreshold(errorsLoggedThreshold: ErrorsLoggedThreshold,
+                                   currentEnvironment: Environment): Option[YamlErrorsLoggedThresholdAlert] = {
+    Option.when(
+      isGrafanaEnabled(
+        errorsLoggedThreshold.alertingPlatform,
+        currentEnvironment,
+        AlertType.ErrorsLoggedThreshold) && errorsLoggedThreshold.count < Int.MaxValue)(
       YamlErrorsLoggedThresholdAlert(errorsLoggedThreshold.count)
     )
   }
 
   def convertExceptionThreshold(exceptionThreshold: ExceptionThreshold, currentEnvironment: Environment): Option[YamlExceptionThresholdAlert] = {
-    Option.when(isGrafanaEnabled(exceptionThreshold.alertingPlatform, currentEnvironment, AlertType.ExceptionThreshold) && exceptionThreshold.count < Int.MaxValue)(
+    Option.when(
+      isGrafanaEnabled(
+        exceptionThreshold.alertingPlatform,
+        currentEnvironment,
+        AlertType.ExceptionThreshold) && exceptionThreshold.count < Int.MaxValue)(
       YamlExceptionThresholdAlert(
         count = exceptionThreshold.count,
         severity = exceptionThreshold.severity.toString
@@ -139,8 +178,13 @@ object AlertsYamlBuilder {
     )
   }
 
-  def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Http5xxPercentThreshold, currentEnvironment: Environment): Option[YamlHttp5xxPercentThresholdAlert] = {
-    Option.when(isGrafanaEnabled(http5xxPercentThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxPercentThreshold) && http5xxPercentThreshold.percentage <= 100.0)(
+  def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Http5xxPercentThreshold,
+                                      currentEnvironment: Environment): Option[YamlHttp5xxPercentThresholdAlert] = {
+    Option.when(
+      isGrafanaEnabled(
+        http5xxPercentThreshold.alertingPlatform,
+        currentEnvironment,
+        AlertType.Http5xxPercentThreshold) && http5xxPercentThreshold.percentage <= 100.0)(
       YamlHttp5xxPercentThresholdAlert(
         percentage = http5xxPercentThreshold.percentage,
         minimumHttp5xxCountThreshold = http5xxPercentThreshold.minimumHttp5xxCountThreshold,
@@ -150,66 +194,82 @@ object AlertsYamlBuilder {
   }
 
   def convertHttp5xxThreshold(http5xxThreshold: Http5xxThreshold, currentEnvironment: Environment): Option[YamlHttp5xxThresholdAlert] = {
-    Option.when(isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold) && http5xxThreshold.count < Int.MaxValue)(
+    Option.when(
+      isGrafanaEnabled(http5xxThreshold.alertingPlatform, currentEnvironment, AlertType.Http5xxThreshold) && http5xxThreshold.count < Int.MaxValue)(
       YamlHttp5xxThresholdAlert(
         count = http5xxThreshold.count,
         severity = http5xxThreshold.severity.toString
       )
     )
   }
-  def convertHttpAbsolutePercentSplitThresholdAlert(httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = {
-    val converted =  httpAbsolutePercentSplitThresholds.withFilter(alert => isGrafanaEnabled(alert.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold) && alert.absoluteThreshold < Int.MaxValue).map {
-      threshold =>
+
+  def convertHttpAbsolutePercentSplitThresholdAlert(httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold],
+                                                    currentEnvironment: Environment): Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = {
+    val converted = httpAbsolutePercentSplitThresholds
+      .withFilter(alert =>
+        isGrafanaEnabled(
+          alert.alertingPlatform,
+          currentEnvironment,
+          AlertType.HttpAbsolutePercentSplitThreshold) && alert.absoluteThreshold < Int.MaxValue)
+      .map { threshold =>
         YamlHttpAbsolutePercentSplitThresholdAlert(
-          percentThreshold  = threshold.percentThreshold,
-          crossover         = threshold.crossOver,
+          percentThreshold = threshold.percentThreshold,
+          crossover = threshold.crossOver,
           absoluteThreshold = threshold.absoluteThreshold,
-          hysteresis        = threshold.hysteresis,
-          excludeSpikes     = threshold.excludeSpikes,
-          errorFilter       = threshold.errorFilter,
-          severity          = threshold.severity.toString
+          hysteresis = threshold.hysteresis,
+          excludeSpikes = threshold.excludeSpikes,
+          errorFilter = threshold.errorFilter,
+          severity = threshold.severity.toString
         )
-    }
+      }
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertHttpStatusThresholds(httpStatusThresholds: Seq[HttpStatusThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpStatusThresholdAlert]] = {
-    val converted = httpStatusThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).map { threshold =>
-      YamlHttpStatusThresholdAlert(
-        count = threshold.count,
-        httpMethod = threshold.httpMethod.toString,
-        httpStatus = threshold.httpStatus.status,
-        severity = threshold.severity.toString
-      )
-    }
+  def convertHttpStatusThresholds(httpStatusThresholds: Seq[HttpStatusThreshold],
+                                  currentEnvironment: Environment): Option[Seq[YamlHttpStatusThresholdAlert]] = {
+    val converted =
+      httpStatusThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).map { threshold =>
+        YamlHttpStatusThresholdAlert(
+          count = threshold.count,
+          httpMethod = threshold.httpMethod.toString,
+          httpStatus = threshold.httpStatus.status,
+          severity = threshold.severity.toString
+        )
+      }
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertLogMessageThresholdAlerts(logMessageThresholds: Seq[LogMessageThreshold], currentEnvironment: Environment): Option[Seq[YamlLogMessageThresholdAlert]] = {
-    val converted = logMessageThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).map { threshold =>
-      YamlLogMessageThresholdAlert(
-        message = threshold.message,
-        count = threshold.count,
-        lessThanMode = threshold.lessThanMode,
-        severity = threshold.severity.toString
-      )
-    }
+  def convertLogMessageThresholdAlerts(logMessageThresholds: Seq[LogMessageThreshold],
+                                       currentEnvironment: Environment): Option[Seq[YamlLogMessageThresholdAlert]] = {
+    val converted =
+      logMessageThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).map { threshold =>
+        YamlLogMessageThresholdAlert(
+          message = threshold.message,
+          count = threshold.count,
+          lessThanMode = threshold.lessThanMode,
+          severity = threshold.severity.toString
+        )
+      }
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertHttpStatusPercentThresholdAlerts(httpStatusPercentThresholds: Seq[HttpStatusPercentThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpStatusPercentThresholdAlert]] = {
-    val converted = httpStatusPercentThresholds.withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).map { threshold =>
-      YamlHttpStatusPercentThresholdAlert(
-        percentage = threshold.percentage,
-        httpMethod = threshold.httpMethod.toString,
-        httpStatus = threshold.httpStatus.status,
-        severity = threshold.severity.toString
-      )
-    }
+  def convertHttpStatusPercentThresholdAlerts(httpStatusPercentThresholds: Seq[HttpStatusPercentThreshold],
+                                              currentEnvironment: Environment): Option[Seq[YamlHttpStatusPercentThresholdAlert]] = {
+    val converted = httpStatusPercentThresholds
+      .withFilter(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold))
+      .map { threshold =>
+        YamlHttpStatusPercentThresholdAlert(
+          percentage = threshold.percentage,
+          httpMethod = threshold.httpMethod.toString,
+          httpStatus = threshold.httpStatus.status,
+          severity = threshold.severity.toString
+        )
+      }
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertHttpTrafficThresholds(httpTrafficThresholds: Seq[HttpTrafficThreshold], currentEnvironment: Environment): Option[Seq[YamlHttpTrafficThresholdAlert]] = {
+  def convertHttpTrafficThresholds(httpTrafficThresholds: Seq[HttpTrafficThreshold],
+                                   currentEnvironment: Environment): Option[Seq[YamlHttpTrafficThresholdAlert]] = {
     val converted = httpTrafficThresholds.flatMap { threshold =>
       if (isGrafanaEnabled(threshold.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold)) {
         Seq(
@@ -235,8 +295,13 @@ object AlertsYamlBuilder {
     Option.when(converted.nonEmpty)(converted)
   }
 
-  def convertTotalHttpRequestThreshold(totalHttpRequestThreshold: TotalHttpRequestThreshold, currentEnvironment: Environment): Option[YamlTotalHttpRequestThresholdAlert] = {
-    Option.when(isGrafanaEnabled(totalHttpRequestThreshold.alertingPlatform, currentEnvironment, AlertType.TotalHttpRequestThreshold) && totalHttpRequestThreshold.count < Int.MaxValue)(
+  def convertTotalHttpRequestThreshold(totalHttpRequestThreshold: TotalHttpRequestThreshold,
+                                       currentEnvironment: Environment): Option[YamlTotalHttpRequestThresholdAlert] = {
+    Option.when(
+      isGrafanaEnabled(
+        totalHttpRequestThreshold.alertingPlatform,
+        currentEnvironment,
+        AlertType.TotalHttpRequestThreshold) && totalHttpRequestThreshold.count < Int.MaxValue)(
       YamlTotalHttpRequestThresholdAlert(totalHttpRequestThreshold.count)
     )
   }
@@ -271,8 +336,8 @@ object AlertsYamlBuilder {
     Option.when(converted.nonEmpty)(converted)
   }
 
-
-  def convertHttp90PercentileResponseTimeThreshold(http90PercentileResponseTimeThreshold: Seq[Http90PercentileResponseTimeThreshold], currentEnvironment: Environment): Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = {
+  def convertHttp90PercentileResponseTimeThreshold(http90PercentileResponseTimeThreshold: Seq[Http90PercentileResponseTimeThreshold],
+                                                   currentEnvironment: Environment): Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = {
     val converted = http90PercentileResponseTimeThreshold.flatMap { threshold =>
       if (isGrafanaEnabled(threshold.alertingPlatform, currentEnvironment, AlertType.Http90PercentileResponseTimeThreshold)) {
         Seq(

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
@@ -21,24 +21,24 @@ case class TopLevelConfig(services: Seq[ServiceConfig])
 case class ServiceConfig(service: String, alerts: Alerts, pagerduty: Seq[PagerDuty])
 
 case class Alerts(
-  averageCPUThreshold: Option[YamlAverageCPUThresholdAlert] = None,
-  containerKillThreshold: Option[YamlContainerKillThresholdAlert] = None,
-  errorsLoggedThreshold: Option[YamlErrorsLoggedThresholdAlert] = None,
-  exceptionThreshold: Option[YamlExceptionThresholdAlert] = None,
-  logMessageThresholds: Option[Seq[YamlLogMessageThresholdAlert]] = None,
-  http5xxThreshold: Option[YamlHttp5xxThresholdAlert] = None,
-  http5xxPercentThreshold: Option[YamlHttp5xxPercentThresholdAlert] = None,
-  httpAbsolutePercentSplitThreshold: Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = None,
-  httpStatusPercentThresholds: Option[Seq[YamlHttpStatusPercentThresholdAlert]] = None,
-  httpStatusThresholds: Option[Seq[YamlHttpStatusThresholdAlert]] = None,
-  httpTrafficThresholds: Option[Seq[YamlHttpTrafficThresholdAlert]] = None,
-  totalHttpRequestThreshold: Option[YamlTotalHttpRequestThresholdAlert] = None,
-  metricsThresholds: Option[Seq[YamlMetricsThresholdAlert]] = None,
-  http90PercentileResponseTimeThreshold: Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = None,
+    averageCPUThreshold: Option[YamlAverageCPUThresholdAlert] = None,
+    containerKillThreshold: Option[YamlContainerKillThresholdAlert] = None,
+    errorsLoggedThreshold: Option[YamlErrorsLoggedThresholdAlert] = None,
+    exceptionThreshold: Option[YamlExceptionThresholdAlert] = None,
+    logMessageThresholds: Option[Seq[YamlLogMessageThresholdAlert]] = None,
+    http5xxThreshold: Option[YamlHttp5xxThresholdAlert] = None,
+    http5xxPercentThreshold: Option[YamlHttp5xxPercentThresholdAlert] = None,
+    httpAbsolutePercentSplitThreshold: Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = None,
+    httpStatusPercentThresholds: Option[Seq[YamlHttpStatusPercentThresholdAlert]] = None,
+    httpStatusThresholds: Option[Seq[YamlHttpStatusThresholdAlert]] = None,
+    httpTrafficThresholds: Option[Seq[YamlHttpTrafficThresholdAlert]] = None,
+    totalHttpRequestThreshold: Option[YamlTotalHttpRequestThresholdAlert] = None,
+    metricsThresholds: Option[Seq[YamlMetricsThresholdAlert]] = None,
+    http90PercentileResponseTimeThreshold: Option[Seq[YamlHttp90PercentileResponseTimeThresholdAlert]] = None
 )
 
 case class PagerDuty(
-  // name: String,
-  integrationKeyName: String
-  // slackChannel: String
+    // name: String,
+    integrationKeyName: String
+    // slackChannel: String
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -28,7 +28,10 @@ object IntegrationsYamlBuilder {
 
   val logger = new Logger()
 
-  def generate(environmentAlertBuilders: Seq[EnvironmentAlertBuilder], customAlertConfigs: Seq[CustomAlertConfig], currentEnvironment: Environment, saveLocation: File): Unit = {
+  def generate(environmentAlertBuilders: Seq[EnvironmentAlertBuilder],
+               customAlertConfigs: Seq[CustomAlertConfig],
+               currentEnvironment: Environment,
+               saveLocation: File): Unit = {
     logger.debug(s"Generating integrations YAML for $currentEnvironment")
     val enabledIntegrations = environmentAlertBuilders.flatMap { builder =>
       val enabledEnvironments = builder.enabledEnvironments

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
@@ -17,84 +17,84 @@
 package uk.gov.hmrc.alertconfig.builder.yaml
 
 case class YamlAverageCPUThresholdAlert(
-  count: Int
+    count: Int
 )
 
 case class YamlContainerKillThresholdAlert(
-  count: Int
+    count: Int
 )
 
 case class YamlErrorsLoggedThresholdAlert(
-  count: Int
+    count: Int
 )
 
 case class YamlExceptionThresholdAlert(
-  count: Int,
-  severity: String
+    count: Int,
+    severity: String
 )
 
 case class YamlHttp5xxPercentThresholdAlert(
-  percentage: Double,
-  minimumHttp5xxCountThreshold: Int,
-  severity: String
+    percentage: Double,
+    minimumHttp5xxCountThreshold: Int,
+    severity: String
 )
 
 case class YamlHttp5xxThresholdAlert(
-  count: Int,
-  severity: String
+    count: Int,
+    severity: String
 )
 
 case class YamlHttpAbsolutePercentSplitThresholdAlert(
-  percentThreshold: Double,
-  crossover: Int,
-  absoluteThreshold: Int,
-  hysteresis: Double,
-  excludeSpikes: Int,
-  errorFilter: String,
-  severity: String
+    percentThreshold: Double,
+    crossover: Int,
+    absoluteThreshold: Int,
+    hysteresis: Double,
+    excludeSpikes: Int,
+    errorFilter: String,
+    severity: String
 )
 
 case class YamlHttpStatusThresholdAlert(
-  count: Int = 1,
-  httpMethod: String,
-  httpStatus: Int,
-  severity: String
+    count: Int = 1,
+    httpMethod: String,
+    httpStatus: Int,
+    severity: String
 )
 
 case class YamlHttpStatusPercentThresholdAlert(
-  percentage: Double,
-  httpMethod: String,
-  httpStatus: Int,
-  severity: String
+    percentage: Double,
+    httpMethod: String,
+    httpStatus: Int,
+    severity: String
 )
 
 case class YamlLogMessageThresholdAlert(
-  count: Int,
-  lessThanMode: Boolean,
-  message: String,
-  severity: String
+    count: Int,
+    lessThanMode: Boolean,
+    message: String,
+    severity: String
 )
 
 case class YamlHttpTrafficThresholdAlert(
-  count: Int,
-  maxMinutesBelowThreshold: Int,
-  severity: String
+    count: Int,
+    maxMinutesBelowThreshold: Int,
+    severity: String
 )
 
 case class YamlMetricsThresholdAlert(
-  count: Double,
-  name: String,
-  query: String,
-  severity: String,
-  invert: Boolean
+    count: Double,
+    name: String,
+    query: String,
+    severity: String,
+    invert: Boolean
 )
 
 case class YamlTotalHttpRequestThresholdAlert(
-  count: Int
+    count: Int
 )
 
 case class YamlHttp90PercentileResponseTimeThresholdAlert(
-  timePeriod: Int,
-  count: Int,
-  severity: String
+    timePeriod: Int,
+    count: Int,
+    severity: String
 )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -53,10 +53,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"         -> JsString("critical"),
+        "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"       -> JsNumber(100),
-        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        "percentage"                   -> JsNumber(100),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
       config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
       config("containerKillThreshold") shouldBe JsNumber(56)
@@ -182,7 +182,13 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     "disable http status percent threshold with given thresholds and severities, when alerting platform is Grafana" in {
       val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
-        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana))
+        .withHttpStatusPercentThreshold(
+          HttpStatusPercentThreshold(
+            HttpStatus.HTTP_STATUS_502,
+            2.2,
+            AlertSeverity.Warning,
+            HttpMethod.Post,
+            alertingPlatform = AlertingPlatform.Grafana))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_504, 4.4, alertingPlatform = AlertingPlatform.Grafana))
         .build
         .get
@@ -195,7 +201,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     "disable http status percent threshold when alerting platform is Grafana" in {
       val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
-        .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post, AlertingPlatform.Grafana))
+        .withHttpStatusPercentThreshold(
+          HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 2.2, AlertSeverity.Warning, HttpMethod.Post, AlertingPlatform.Grafana))
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_504, 4.4, alertingPlatform = AlertingPlatform.Grafana))
         .build
         .get
@@ -357,8 +364,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
           "hysteresis"        -> JsNumber(1.0),
           "percentThreshold"  -> JsNumber(100.0),
           "severity"          -> JsString("critical"),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
-      ))
+          "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
+        ))
 
       serviceConfig("absolute-percentage-split-threshold") shouldBe expected
     }
@@ -378,31 +385,35 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
       serviceConfig("metricsThresholds") shouldBe JsArray(
         JsObject(
-          "name"        -> JsString("alert1"),
-          "query"       -> JsString(query),
-          "warning"     -> JsNumber(65.0),
-          "critical"    -> JsNumber(88.0),
-          "invert"      -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
+          "name"             -> JsString("alert1"),
+          "query"            -> JsString(query),
+          "warning"          -> JsNumber(65.0),
+          "critical"         -> JsNumber(88.0),
+          "invert"           -> JsBoolean(false),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        ),
         JsObject(
-          "name" -> JsString("alert1-warning-only"),
-          "query"  -> JsString(query),
-          "warning"  -> JsNumber(44.0),
-          "invert" -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
+          "name"             -> JsString("alert1-warning-only"),
+          "query"            -> JsString(query),
+          "warning"          -> JsNumber(44.0),
+          "invert"           -> JsBoolean(false),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        ),
         JsObject(
-          "name" -> JsString("alert1-critical-only"),
-          "query" -> JsString(query),
-          "critical" -> JsNumber(45.0),
-          "invert" -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)),
+          "name"             -> JsString("alert1-critical-only"),
+          "query"            -> JsString(query),
+          "critical"         -> JsNumber(45.0),
+          "invert"           -> JsBoolean(false),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        ),
         JsObject(
-          "name"     -> JsString("alert2"),
-          "query"    -> JsString(query),
-          "warning"  -> JsNumber(30.03),
-          "critical" -> JsNumber(12.21),
-          "invert"   -> JsBoolean(true),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
+          "name"             -> JsString("alert2"),
+          "query"            -> JsString(query),
+          "warning"          -> JsNumber(30.03),
+          "critical"         -> JsNumber(12.21),
+          "invert"           -> JsBoolean(true),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        )
       )
     }
 
@@ -410,9 +421,18 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       val query = "some_function(over.some.query.for.anything.like*)"
       val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withMetricsThreshold(MetricsThreshold(name = "alert1", query = query, warning = Some(65), critical = Some(88)))
-        .withMetricsThreshold(MetricsThreshold(name = "alert1-warning-only", query = query, warning = Some(44), alertingPlatform = AlertingPlatform.Grafana))
-        .withMetricsThreshold(MetricsThreshold(name = "alert1-critical-only", query = query, critical = Some(45), alertingPlatform = AlertingPlatform.Grafana))
-        .withMetricsThreshold(MetricsThreshold(name = "alert2", query = query, warning = Some(30.03), critical = Some(12.21), invert = true, alertingPlatform = AlertingPlatform.Grafana))
+        .withMetricsThreshold(
+          MetricsThreshold(name = "alert1-warning-only", query = query, warning = Some(44), alertingPlatform = AlertingPlatform.Grafana))
+        .withMetricsThreshold(
+          MetricsThreshold(name = "alert1-critical-only", query = query, critical = Some(45), alertingPlatform = AlertingPlatform.Grafana))
+        .withMetricsThreshold(
+          MetricsThreshold(
+            name = "alert2",
+            query = query,
+            warning = Some(30.03),
+            critical = Some(12.21),
+            invert = true,
+            alertingPlatform = AlertingPlatform.Grafana))
         .build
         .get
         .parseJson
@@ -421,12 +441,13 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
       serviceConfig("metricsThresholds") shouldBe JsArray(
         JsObject(
-          "name" -> JsString("alert1"),
-          "query" -> JsString(query),
-          "warning" -> JsNumber(65.0),
-          "critical" -> JsNumber(88.0),
-          "invert" -> JsBoolean(false),
-          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)))
+          "name"             -> JsString("alert1"),
+          "query"            -> JsString(query),
+          "warning"          -> JsNumber(65.0),
+          "critical"         -> JsNumber(88.0),
+          "invert"           -> JsBoolean(false),
+          "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        ))
     }
 
   }
@@ -458,7 +479,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         "hysteresis"        -> JsNumber(hysteresis),
         "percentThreshold"  -> JsNumber(percent),
         "severity"          -> JsString("warning"),
-        "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString))
+        "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
+      )
     )
 
     serviceConfig("absolute-percentage-split-threshold") shouldBe expected
@@ -640,10 +662,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
-      "severity"         -> JsString("critical"),
+      "severity"                     -> JsString("critical"),
       "minimumHttp5xxCountThreshold" -> JsNumber(0),
-      "percentage"       -> JsNumber(threshold),
-      "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+      "percentage"                   -> JsNumber(threshold),
+      "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
     )
   }
 
@@ -658,10 +680,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
-      "severity"         -> JsString("critical"),
+      "severity"                     -> JsString("critical"),
       "minimumHttp5xxCountThreshold" -> JsNumber(10),
-      "percentage"       -> JsNumber(threshold),
-      "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+      "percentage"                   -> JsNumber(threshold),
+      "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
     )
   }
 
@@ -677,10 +699,10 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       .fields
 
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
-      "severity"         -> JsString("critical"),
+      "severity"                     -> JsString("critical"),
       "minimumHttp5xxCountThreshold" -> JsNumber(0),
-      "percentage"       -> JsNumber(disabledThreshold),
-      "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
+      "percentage"                   -> JsNumber(disabledThreshold),
+      "alertingPlatform"             -> JsString(AlertingPlatform.Grafana.toString)
     )
   }
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentVars.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentVars.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.alertconfig.builder
 
 object EnvironmentVars {
+
   def setEnv(key: String, value: String) = {
     val field = System.getenv().getClass.getDeclaredField("m")
     field.setAccessible(true)
@@ -30,4 +31,5 @@ object EnvironmentVars {
     val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
     map.remove(key)
   }
+
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/ObjectScannerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/ObjectScannerSpec.scala
@@ -31,7 +31,8 @@ class ObjectScannerSpec extends AnyWordSpec with Matchers {
 
   "ClassScanner" should {
     "load all the singleton subtypes of a type in given package" in {
-      ObjectScanner.loadAll[SuperType](this.getClass.getPackage.getName) should contain.only (A, B)
+      ObjectScanner.loadAll[SuperType](this.getClass.getPackage.getName) should contain.only(A, B)
     }
   }
+
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -50,17 +50,18 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
 
     "result in identical defaults to AlertConfigBuilder" in {
       val teamAlertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1"))
-      val alertConfigBuilder = AlertConfigBuilder("service1")
+      val alertConfigBuilder     = AlertConfigBuilder("service1")
 
       val teamConfigs = teamAlertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
-      val configs = alertConfigBuilder.build.get.parseJson.asJsObject.fields
+      val configs     = alertConfigBuilder.build.get.parseJson.asJsObject.fields
 
       teamConfigs shouldBe List(configs)
     }
 
     "result in identical config to AlertConfigBuilder" in {
-      val teamAlertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1"
-        )).withAverageCPUThreshold(50)
+      val teamAlertConfigBuilder = TeamAlertConfigBuilder
+        .teamAlerts(Seq("service1"))
+        .withAverageCPUThreshold(50)
         .withContainerKillThreshold(2)
         .withErrorsLoggedThreshold(5)
         .withExceptionThreshold(3)
@@ -68,7 +69,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
         .withHttp5xxThreshold(15)
         .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 90))
         .withHttpStatusThreshold(HttpStatusThreshold(HttpStatus.HTTP_STATUS_502, 10))
-        .withHttpTrafficThreshold(HttpTrafficThreshold(None, critical=Some(1000)))
+        .withHttpTrafficThreshold(HttpTrafficThreshold(None, critical = Some(1000)))
         .withLogMessageThreshold("BLAH", 1)
         .withTotalHttpRequestsCountThreshold(2000)
 
@@ -86,7 +87,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
         .withTotalHttpRequestsCountThreshold(2000)
 
       val teamConfigs = teamAlertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
-      val configs = alertConfigBuilder.build.get.parseJson.asJsObject.fields
+      val configs     = alertConfigBuilder.build.get.parseJson.asJsObject.fields
 
       teamConfigs shouldBe List(configs)
     }
@@ -94,8 +95,9 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     "result in identical config to AlertConfigBuilder in migrated environment" in {
       EnvironmentVars.setEnv("ENVIRONMENT", "integration")
 
-      val teamAlertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1"
-        )).withAverageCPUThreshold(50)
+      val teamAlertConfigBuilder = TeamAlertConfigBuilder
+        .teamAlerts(Seq("service1"))
+        .withAverageCPUThreshold(50)
         .withContainerKillThreshold(2)
         .withErrorsLoggedThreshold(5)
         .withExceptionThreshold(3)
@@ -121,7 +123,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
         .withTotalHttpRequestsCountThreshold(2000)
 
       val teamConfigs = teamAlertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
-      val configs = alertConfigBuilder.build.get.parseJson.asJsObject.fields
+      val configs     = alertConfigBuilder.build.get.parseJson.asJsObject.fields
 
       teamConfigs shouldBe List(configs)
 
@@ -175,7 +177,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "percentThreshold"  -> JsNumber(percent),
           "severity"          -> JsString(severity.toString),
           "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
-      ))
+        ))
 
       service1Config("absolute-percentage-split-threshold") shouldBe expected
       service2Config("absolute-percentage-split-threshold") shouldBe expected
@@ -271,22 +273,22 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service2Config = configs(1)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"         -> JsString("critical"),
+        "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"       -> JsNumber(threshold),
-        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        "percentage"                   -> JsNumber(threshold),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"         -> JsString("critical"),
+        "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"       -> JsNumber(threshold),
-        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        "percentage"                   -> JsNumber(threshold),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
     }
 
     "return TeamAlertConfigBuilder with disabled Http5xxPercentThreshold when alerting platform is Grafana" in {
-      val threshold          = 19.9
-      val disabledThreshold  = 333.33
+      val threshold         = 19.9
+      val disabledThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
         .withHttp5xxPercentThreshold(threshold, alertingPlatform = AlertingPlatform.Grafana)
@@ -299,16 +301,16 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service2Config = configs(1)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"         -> JsString("critical"),
+        "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"       -> JsNumber(disabledThreshold),
-        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
+        "percentage"                   -> JsNumber(disabledThreshold),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Grafana.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
-        "severity"         -> JsString("critical"),
+        "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"       -> JsNumber(disabledThreshold),
-        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
+        "percentage"                   -> JsNumber(disabledThreshold),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
 
@@ -530,7 +532,8 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      val expected = JsObject("alertingPlatform" -> JsString("Default"), "warning" -> JsNumber(10), "critical" -> JsNumber(5), "timePeriod" -> JsNumber(10))
+      val expected =
+        JsObject("alertingPlatform" -> JsString("Default"), "warning" -> JsNumber(10), "critical" -> JsNumber(5), "timePeriod" -> JsNumber(10))
 
       service1Config("http90PercentileResponseTimeThresholds") shouldBe expected
       service2Config("http90PercentileResponseTimeThresholds") shouldBe expected
@@ -549,7 +552,8 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      val expected = JsObject("alertingPlatform" -> JsString("Grafana"), "warning" -> JsNumber(10), "critical" -> JsNumber(5), "timePeriod" -> JsNumber(10))
+      val expected =
+        JsObject("alertingPlatform" -> JsString("Grafana"), "warning" -> JsNumber(10), "critical" -> JsNumber(5), "timePeriod" -> JsNumber(10))
 
       service1Config("http90PercentileResponseTimeThresholds") shouldBe expected
       service2Config("http90PercentileResponseTimeThresholds") shouldBe expected
@@ -662,7 +666,12 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct httpStatusPercentThresholds" in {
-      val threshold1 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_500, 19.1, AlertSeverity.Warning, HttpMethod.Post, alertingPlatform = AlertingPlatform.Grafana)
+      val threshold1 = HttpStatusPercentThreshold(
+        HttpStatus.HTTP_STATUS_500,
+        19.1,
+        AlertSeverity.Warning,
+        HttpMethod.Post,
+        alertingPlatform = AlertingPlatform.Grafana)
       val threshold2 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_501, 20, alertingPlatform = AlertingPlatform.Grafana)
       val threshold3 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS(555), 55.5, alertingPlatform = AlertingPlatform.Grafana)
       val threshold4 = HttpStatusPercentThreshold(HttpStatus.HTTP_STATUS_502, 10, alertingPlatform = AlertingPlatform.Grafana)
@@ -732,10 +741,10 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"       -> JsNumber(12.2),
+        "percentage"                   -> JsNumber(12.2),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "severity"         -> JsString("warning"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        "severity"                     -> JsString("warning"),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
     }
 
@@ -751,16 +760,16 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"       -> JsNumber(12.2),
+        "percentage"                   -> JsNumber(12.2),
         "minimumHttp5xxCountThreshold" -> JsNumber(15),
-        "severity"         -> JsString("warning"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
+        "severity"                     -> JsString("warning"),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
     }
 
     "return TeamAlertConfigBuilder with disabled withHttp5xxPercentThreshold when alerting platform is Grafana" in {
-      val threshold          = 19.9
-      val disabledThreshold  = 333.33
+      val threshold         = 19.9
+      val disabledThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
@@ -772,34 +781,37 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"       -> JsNumber(disabledThreshold),
+        "percentage"                   -> JsNumber(disabledThreshold),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "severity"         -> JsString("warning"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
+        "severity"                     -> JsString("warning"),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
 
     "return TeamAlertConfigBuilder with disabled withHttp5xxPercentThreshold when alerting platform is Grafana supplying optional minimum http 5xx count" in {
-      val threshold          = 19.9
-      val disabledThreshold  = 333.33
+      val threshold         = 19.9
+      val disabledThreshold = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
         .withLogMessageThreshold("SIMULATED_ERROR2", 20, lessThanMode = true)
-        .withHttp5xxPercentThreshold(threshold, minimumHttp5xxCountThreshold = 12, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
+        .withHttp5xxPercentThreshold(
+          threshold,
+          minimumHttp5xxCountThreshold = 12,
+          severity = AlertSeverity.Warning,
+          alertingPlatform = AlertingPlatform.Grafana)
 
       alertConfigBuilder.services shouldBe Seq("service1")
       val configs                              = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"       -> JsNumber(disabledThreshold),
+        "percentage"                   -> JsNumber(disabledThreshold),
         "minimumHttp5xxCountThreshold" -> JsNumber(12),
-        "severity"         -> JsString("warning"),
-        "alertingPlatform" -> JsString(AlertingPlatform.Grafana.toString)
+        "severity"                     -> JsString("warning"),
+        "alertingPlatform"             -> JsString(AlertingPlatform.Grafana.toString)
       )
     }
-
 
     "return TeamAlertConfigBuilder with correct logMessageThresholds" in {
       val alertConfigBuilder = TeamAlertConfigBuilder

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -19,7 +19,24 @@ package uk.gov.hmrc.alertconfig.builder.yaml
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.alertconfig.builder.{AlertConfig, AlertConfigBuilder, AlertSeverity, AlertingPlatform, Environment, EnvironmentAlertBuilder, Http90PercentileResponseTimeThreshold, HttpAbsolutePercentSplitDownstreamHodThreshold, HttpAbsolutePercentSplitDownstreamServiceThreshold, HttpAbsolutePercentSplitThreshold, HttpStatus, HttpStatusPercentThreshold, HttpStatusThreshold, HttpTrafficThreshold, MetricsThreshold, Severity}
+import uk.gov.hmrc.alertconfig.builder.{
+  AlertConfig,
+  AlertConfigBuilder,
+  AlertSeverity,
+  AlertingPlatform,
+  Environment,
+  EnvironmentAlertBuilder,
+  Http90PercentileResponseTimeThreshold,
+  HttpAbsolutePercentSplitDownstreamHodThreshold,
+  HttpAbsolutePercentSplitDownstreamServiceThreshold,
+  HttpAbsolutePercentSplitThreshold,
+  HttpStatus,
+  HttpStatusPercentThreshold,
+  HttpStatusThreshold,
+  HttpTrafficThreshold,
+  MetricsThreshold,
+  Severity
+}
 
 class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
@@ -39,7 +56,12 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       val config = AlertConfigBuilder("service-without-app-config-entry", integrations = Seq("h1", "h2"))
         .withContainerKillThreshold(10, AlertingPlatform.Grafana)
 
-      val res    = AlertsYamlBuilder.convert(alertConfigBuilder = config, environmentDefinedIntegrations = Set("h1"), currentEnvironment = Environment.Production, integrationSeveritiesForEnv = Map("h1" -> Set(Severity.Warning, Severity.Critical)))
+      val res = AlertsYamlBuilder.convert(
+        alertConfigBuilder = config,
+        environmentDefinedIntegrations = Set("h1"),
+        currentEnvironment = Environment.Production,
+        integrationSeveritiesForEnv = Map("h1" -> Set(Severity.Warning, Severity.Critical))
+      )
 
       res shouldBe None
     }
@@ -49,7 +71,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
     "not create the alerts defined with a warning severity" in {
 
       val envConfig = Seq(
-        EnvironmentAlertBuilder("integration-non-prod", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Critical))),
+        EnvironmentAlertBuilder("integration-non-prod", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Critical)))
       )
 
       val alertConfigBuilders = Seq(
@@ -63,7 +85,8 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           .withHttp5xxPercentThreshold(1, severity = AlertSeverity.Warning, alertingPlatform = AlertingPlatform.Grafana)
           .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1), critical = None))
           .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(severity = AlertSeverity.Warning))
-          .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(severity = AlertSeverity.Warning))
+          .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(severity =
+            AlertSeverity.Warning))
           .withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(severity = AlertSeverity.Warning))
           .withContainerKillThreshold(2, AlertingPlatform.Grafana)
           .withHttpTrafficThreshold(HttpTrafficThreshold(warning = Some(1), critical = Some(2), alertingPlatform = AlertingPlatform.Grafana))
@@ -77,7 +100,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       )
 
       val fakeConfig = new AlertConfig {
-        override def alertConfig: Seq[AlertConfigBuilder] = alertConfigBuilders
+        override def alertConfig: Seq[AlertConfigBuilder]            = alertConfigBuilders
         override def environmentConfig: Seq[EnvironmentAlertBuilder] = envConfig
       }
 
@@ -94,7 +117,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
             http5xxThreshold = None,
             http5xxPercentThreshold = None,
             httpStatusPercentThresholds = None,
-            httpStatusThresholds = Some(Seq(YamlHttpStatusThresholdAlert(1, "ALL_METHODS", 501, "critical" ))),
+            httpStatusThresholds = Some(Seq(YamlHttpStatusThresholdAlert(1, "ALL_METHODS", 501, "critical"))),
             httpTrafficThresholds = Some(Seq(YamlHttpTrafficThresholdAlert(2, 5, "critical"))),
             totalHttpRequestThreshold = Some(YamlTotalHttpRequestThresholdAlert(2)),
             metricsThresholds = None,
@@ -114,7 +137,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
 
       val envConfig = Seq(
         EnvironmentAlertBuilder("foo", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Critical, Severity.Warning))),
-        EnvironmentAlertBuilder("bar", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Critical))),
+        EnvironmentAlertBuilder("bar", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Critical)))
       )
 
       val alertConfigBuilders = Seq(
@@ -128,7 +151,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       )
 
       val fakeConfig = new AlertConfig {
-        override def alertConfig: Seq[AlertConfigBuilder] = alertConfigBuilders
+        override def alertConfig: Seq[AlertConfigBuilder]            = alertConfigBuilders
         override def environmentConfig: Seq[EnvironmentAlertBuilder] = envConfig
       }
 
@@ -166,7 +189,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
 
       val envConfig = Seq(
         EnvironmentAlertBuilder("foo", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Critical, Severity.Warning))),
-        EnvironmentAlertBuilder("bar", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Warning))),
+        EnvironmentAlertBuilder("bar", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Warning)))
       )
 
       val alertConfigBuilders = Seq(
@@ -180,7 +203,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       )
 
       val fakeConfig = new AlertConfig {
-        override def alertConfig: Seq[AlertConfigBuilder] = alertConfigBuilders
+        override def alertConfig: Seq[AlertConfigBuilder]            = alertConfigBuilders
         override def environmentConfig: Seq[EnvironmentAlertBuilder] = envConfig
       }
 
@@ -217,7 +240,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
     "not create the alerts defined with a critical severity" in {
 
       val envConfig = Seq(
-        EnvironmentAlertBuilder("integration-non-prod", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Warning))),
+        EnvironmentAlertBuilder("integration-non-prod", enabledEnvironments = Map(Environment.Qa -> Set(Severity.Warning)))
       )
 
       val alertConfigBuilders = Seq(
@@ -231,7 +254,8 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           .withHttp5xxPercentThreshold(1, severity = AlertSeverity.Critical, alertingPlatform = AlertingPlatform.Grafana)
           .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(2), critical = Some(1)))
           .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(severity = AlertSeverity.Critical))
-          .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(severity = AlertSeverity.Critical))
+          .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(severity =
+            AlertSeverity.Critical))
           .withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(severity = AlertSeverity.Critical))
           .withContainerKillThreshold(2, AlertingPlatform.Grafana)
           .withHttpTrafficThreshold(HttpTrafficThreshold(warning = Some(1), critical = Some(2), alertingPlatform = AlertingPlatform.Grafana))
@@ -245,7 +269,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       )
 
       val fakeConfig = new AlertConfig {
-        override def alertConfig: Seq[AlertConfigBuilder] = alertConfigBuilders
+        override def alertConfig: Seq[AlertConfigBuilder]            = alertConfigBuilders
         override def environmentConfig: Seq[EnvironmentAlertBuilder] = envConfig
       }
 
@@ -262,7 +286,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
             http5xxThreshold = None,
             http5xxPercentThreshold = None,
             httpStatusPercentThresholds = None,
-            httpStatusThresholds = Some(Seq(YamlHttpStatusThresholdAlert(1, "ALL_METHODS", 500, "warning" ))),
+            httpStatusThresholds = Some(Seq(YamlHttpStatusThresholdAlert(1, "ALL_METHODS", 500, "warning"))),
             httpTrafficThresholds = Some(Seq(YamlHttpTrafficThresholdAlert(1, 5, "warning"))),
             totalHttpRequestThreshold = Some(YamlTotalHttpRequestThresholdAlert(2)),
             metricsThresholds = Some(Seq(YamlMetricsThresholdAlert(1.0, "metrics", "query", "warning", invert = false))),
@@ -394,4 +418,5 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       output.totalHttpRequestThreshold shouldBe None
     }
   }
+
 }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
@@ -34,8 +34,8 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
 
   "generate" should {
     "create a correctly defined YAML file containing integrations and severities for that env only" in {
-      val tmpDir = Files.createTempDirectory("integrations-test")
-      val testFile = new File(s"$tmpDir/integrations.yaml")
+      val tmpDir             = Files.createTempDirectory("integrations-test")
+      val testFile           = new File(s"$tmpDir/integrations.yaml")
       val currentEnvironment = Environment.Production
 
       val environmentAlertBuilders: Seq[EnvironmentAlertBuilder] = Seq(
@@ -60,8 +60,7 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
           |      - warning
           |  - name: team-telemetry-critical-only
           |    severitiesEnabled:
-          |      - critical"""
-          .stripMargin
+          |      - critical""".stripMargin
 
     }
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -20,7 +20,17 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import uk.gov.hmrc.alertconfig.builder.HttpStatus.HTTP_STATUS
-import uk.gov.hmrc.alertconfig.builder.{AlertConfigBuilder, AlertSeverity, AlertingPlatform, Environment, HttpAbsolutePercentSplitThreshold, HttpStatusPercentThreshold, HttpStatusThreshold, HttpTrafficThreshold, MetricsThreshold}
+import uk.gov.hmrc.alertconfig.builder.{
+  AlertConfigBuilder,
+  AlertSeverity,
+  AlertingPlatform,
+  Environment,
+  HttpAbsolutePercentSplitThreshold,
+  HttpStatusPercentThreshold,
+  HttpStatusThreshold,
+  HttpTrafficThreshold,
+  MetricsThreshold
+}
 
 class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
@@ -270,7 +280,8 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.httpAbsolutePercentSplitThreshold shouldBe Some(List(YamlHttpAbsolutePercentSplitThresholdAlert(50, 1, 2, 1, 2, "status:>501", "critical")))
+      output.httpAbsolutePercentSplitThreshold shouldBe Some(
+        List(YamlHttpAbsolutePercentSplitThresholdAlert(50, 1, 2, 1, 2, "status:>501", "critical")))
     }
 
     "httpAbsolutePercentSplitThreshold should be disabled if alertPlatform is Sensu" in {
@@ -404,7 +415,8 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(count = 60, lessThanMode = false, message = "LOG_MESSAGE", severity = "critical")))
+      output.logMessageThresholds shouldBe Some(
+        List(YamlLogMessageThresholdAlert(count = 60, lessThanMode = false, message = "LOG_MESSAGE", severity = "critical")))
     }
 
     "LogMessageThreshold should be disabled if alertingPlatform is Sensu" in {
@@ -422,7 +434,8 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
-      output.logMessageThresholds shouldBe Some(List(YamlLogMessageThresholdAlert(count = 60, lessThanMode = false, message = "LOG_MESSAGE", severity = "critical")))
+      output.logMessageThresholds shouldBe Some(
+        List(YamlLogMessageThresholdAlert(count = 60, lessThanMode = false, message = "LOG_MESSAGE", severity = "critical")))
     }
 
     "LogMessageThreshold should be disabled by default in production" in {
@@ -440,7 +453,8 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(count = 1, name = "metric", query = "a.b.c.d", severity = "critical", invert = false)))
+      output.metricsThresholds shouldBe Some(
+        List(YamlMetricsThresholdAlert(count = 1, name = "metric", query = "a.b.c.d", severity = "critical", invert = false)))
     }
 
     "MetricsThreshold should be disabled if alertingPlatform is Sensu" in {
@@ -458,7 +472,8 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Integration)
 
-      output.metricsThresholds shouldBe Some(List(YamlMetricsThresholdAlert(count = 1, name = "metric", query = "a.b.c.d", severity = "critical", invert = false)))
+      output.metricsThresholds shouldBe Some(
+        List(YamlMetricsThresholdAlert(count = 1, name = "metric", query = "a.b.c.d", severity = "critical", invert = false)))
     }
 
     "MetricsThreshold should be disabled by default in production" in {
@@ -506,4 +521,5 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       output.totalHttpRequestThreshold shouldBe Some(YamlTotalHttpRequestThresholdAlert(60))
     }
   }
+
 }


### PR DESCRIPTION
What did we do?
--

[This](https://github.com/hmrc/alert-config-builder/commit/1145da8073d906e1fd9774340ab3d5d0127f3bd4) is the actual change to review

1. Allow setting thresholds for prod or non-prod environments
2. Apply scala fmt

This is to allow us to easily control where an alert should be deployed too, see the currently duplicated ones
![image](https://github.com/hmrc/alert-config-builder/assets/1422984/22f2fc65-064d-452f-9ef5-ee54d9e29c89)



References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4450

Evidence of work
--

![image](https://github.com/hmrc/alert-config-builder/assets/1422984/d9019e82-e937-414d-9f72-34ab29cd45a8)


Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by:
