### PR TITLE
TEL-4555 Roll httpTrafficThreshold back to Sensu in prod, following u…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -133,7 +133,7 @@ object GrafanaMigration {
       AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold                   -> AlertingPlatform.Sensu,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Sensu,
       AlertType.LogMessageThreshold                   -> AlertingPlatform.Sensu,
       AlertType.MetricsThreshold                      -> AlertingPlatform.Sensu,
       AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -301,7 +301,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       )
     }
 
-    "disable httpTrafficThreshold with given thresholds when alerting platform is Sensu" in {
+    "configure httpTrafficThreshold with given thresholds when alerting platform is Sensu" in {
       val threshold = HttpTrafficThreshold(Some(10), Some(5), 35)
       val serviceConfig = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(threshold)
@@ -311,7 +311,14 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .asJsObject
         .fields
 
-      serviceConfig("httpTrafficThresholds") shouldBe JsArray()
+      serviceConfig("httpTrafficThresholds") shouldBe JsArray(
+        JsObject(
+          "warning"                  -> JsNumber(10),
+          "critical"                 -> JsNumber(5),
+          "maxMinutesBelowThreshold" -> JsNumber(35),
+          "alertingPlatform"         -> JsString(AlertingPlatform.Default.toString)
+        )
+      )
     }
 
     "disable httpTrafficThreshold in Sensu when alerting platform is Grafana" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -571,7 +571,14 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      val expected = JsArray()
+      val expected = JsArray(
+        JsObject(
+          "warning"                  -> JsNumber(10),
+          "critical"                 -> JsNumber(5),
+          "maxMinutesBelowThreshold" -> JsNumber(35),
+          "alertingPlatform"         -> JsString("Default")
+        )
+      )
 
       service1Config("httpTrafficThresholds") shouldBe expected
       service2Config("httpTrafficThresholds") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -400,14 +400,13 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
       output.httpTrafficThresholds shouldBe Some(List(YamlHttpTrafficThresholdAlert(60, 5, "critical")))
     }
 
-    "HttpTrafficThreshold should be enabled by default in production" in {
+    "HttpTrafficThreshold should be disabled by default in production" in {
       val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withHttpTrafficThreshold(HttpTrafficThreshold(None, Some(60)))
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.httpTrafficThresholds shouldBe Some(
-        List(YamlHttpTrafficThresholdAlert(count = 60, maxMinutesBelowThreshold = 5, severity = "critical")))
+      output.httpTrafficThresholds shouldBe None
     }
 
     "LogMessageThreshold should be enabled if alertingPlatform is Grafana" in {


### PR DESCRIPTION
…nexpected alerts post-migration

What did we do?
--

1. Revert

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4555


Next Steps
--

1. Roll out in alert-config

Risks
--

1. Just putting it back to how it always was 2 days ago.

