### PR TITLE
TEL-4504 Extend custom-alerts to allow overriding of environment config

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlert.scala
@@ -15,7 +15,10 @@
  */
 
 package uk.gov.hmrc.alertconfig.builder.custom
+import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 
 trait CustomAlert {
   def thresholds: EnvironmentThresholds
+  def severity: AlertSeverity
+  def integrations: Seq[String]
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertConfig.scala
@@ -16,7 +16,10 @@
 
 package uk.gov.hmrc.alertconfig.builder.custom
 
+import uk.gov.hmrc.alertconfig.builder.EnvironmentAlertBuilder
+
 trait CustomAlertConfig {
   def customAlerts: Seq[CustomAlert]
 
+  def environmentConfig: Seq[EnvironmentAlertBuilder] = customAlerts.flatMap(_.integrations).map(EnvironmentAlertBuilder(_))
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -29,7 +29,6 @@ object IntegrationsYamlBuilder {
   val logger = new Logger()
 
   def generate(environmentAlertBuilders: Seq[EnvironmentAlertBuilder],
-               customAlertConfigs: Seq[CustomAlertConfig],
                currentEnvironment: Environment,
                saveLocation: File): Unit = {
     logger.debug(s"Generating integrations YAML for $currentEnvironment")

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
@@ -45,7 +45,7 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         // This one should not appear in the output YAML
         EnvironmentAlertBuilder("team-telemetry-non-prod-one").disableProduction().inIntegration(Set(Severity.Warning, Severity.Critical))
       )
-      IntegrationsYamlBuilder.generate(environmentAlertBuilders, Seq(), currentEnvironment, testFile)
+      IntegrationsYamlBuilder.generate(environmentAlertBuilders, currentEnvironment, testFile)
 
       val yamlFromDisk = Source.fromFile(testFile).getLines().mkString("\n")
 


### PR DESCRIPTION
What did we do?
--

1. Extended custom alerts, to also allow overriding of environment config. 
2. Remove unused parameter from IntegrationsYamlBuilder.

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4504

Evidence of work
--

1. N/A

Next Steps
--

1. Build and roll out to alert-config

Risks
--

1. ?

Collaboration
--

Co-authored-by: Gavin Davies [gavD@users.noreply.github.com](mailto:gavD@users.noreply.github.com)
