### PR TITLE
TEL-4535 Add HttpAbsolutePercentSplitDownstreamHodThreshold for Grafana

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -390,49 +390,21 @@ case class AlertConfigBuilder(
              |"app": "$serviceName.$serviceDomain",
              |"handlers": ${integrations.toJson.compactPrint},
              |"errors-logged-threshold":$updatedErrorsLoggedThreshold,
-             |"exception-threshold":${exceptionThreshold
-            .copy(count = updatedExceptionThreshold)
-            .toJson(ExceptionThresholdProtocol.thresholdFormat)
-            .compactPrint},
-             |"5xx-threshold":${http5xxThreshold
-            .copy(count = updated5xxThreshold)
-            .toJson(Http5xxThresholdProtocol.thresholdFormat)
-            .compactPrint},
-             |"5xx-percent-threshold":${http5xxPercentThreshold
-            .copy(percentage = updated5xxPercentThreshold)
-            .toJson(Http5xxPercentThresholdProtocol.thresholdFormat)
-            .compactPrint},
+             |"exception-threshold":${exceptionThreshold.copy(count = updatedExceptionThreshold).toJson(ExceptionThresholdProtocol.thresholdFormat).compactPrint},
+             |"5xx-threshold":${http5xxThreshold.copy(count = updated5xxThreshold).toJson(Http5xxThresholdProtocol.thresholdFormat).compactPrint},
+             |"5xx-percent-threshold":${http5xxPercentThreshold.copy(percentage = updated5xxPercentThreshold).toJson(Http5xxPercentThresholdProtocol.thresholdFormat).compactPrint},
              |"containerKillThreshold" : $updatedContainerKillThreshold,
-             |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption
-            .map(_.toJson.compactPrint)
-            .getOrElse(JsNull)},
-             |"httpTrafficThresholds" : ${httpTrafficThresholds
-            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold))
-            .toJson
-            .compactPrint},
-             |"httpStatusThresholds" : ${httpStatusThresholds
-            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold))
-            .toJson
-            .compactPrint},
-             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds
-            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold))
-            .toJson
-            .compactPrint},
-             |"metricsThresholds" : ${printSeq(metricsThresholds.filterNot(a =>
-            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)))(MetricsThresholdProtocol.thresholdFormat)},
+             |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption.map(_.toJson.compactPrint).getOrElse(JsNull)},
+             |"httpTrafficThresholds" : ${httpTrafficThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold)).toJson.compactPrint},
+             |"httpStatusThresholds" : ${httpStatusThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).toJson.compactPrint},
+             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).toJson.compactPrint},
+             |"metricsThresholds" : ${printSeq(metricsThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)))(MetricsThresholdProtocol.thresholdFormat)},
              |"total-http-request-threshold": $updatedTotalHttpRequestThreshold,
-             |"log-message-thresholds" : ${logMessageThresholds
-            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold))
-            .toJson
-            .compactPrint},
+             |"log-message-thresholds" : ${logMessageThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).toJson.compactPrint},
              |"average-cpu-threshold" : $updatedAverageCPUThreshold,
-             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a =>
-            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(
-            HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
-             |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds)(
-            HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
-             |"absolute-percentage-split-downstream-hod-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamHodThresholds)(
-            HttpAbsolutePercentSplitDownstreamHodThresholdProtocol.thresholdFormat)}
+             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
+             |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds)(HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
+             |"absolute-percentage-split-downstream-hod-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamHodThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold)))(HttpAbsolutePercentSplitDownstreamHodThresholdProtocol.thresholdFormat)}
              |}
               """.stripMargin
       }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -20,20 +20,21 @@ sealed trait AlertType
 
 object AlertType {
 
-  object AverageCPUThreshold                   extends AlertType
-  object ContainerKillThreshold                extends AlertType
-  object ErrorsLoggedThreshold                 extends AlertType
-  object ExceptionThreshold                    extends AlertType
-  object Http5xxPercentThreshold               extends AlertType
-  object Http5xxThreshold                      extends AlertType
-  object HttpAbsolutePercentSplitThreshold     extends AlertType
-  object HttpStatusPercentThreshold            extends AlertType
-  object HttpStatusThreshold                   extends AlertType
-  object HttpTrafficThreshold                  extends AlertType
-  object LogMessageThreshold                   extends AlertType
-  object MetricsThreshold                      extends AlertType
-  object TotalHttpRequestThreshold             extends AlertType
-  object Http90PercentileResponseTimeThreshold extends AlertType
+  object AverageCPUThreshold                                extends AlertType
+  object ContainerKillThreshold                             extends AlertType
+  object ErrorsLoggedThreshold                              extends AlertType
+  object ExceptionThreshold                                 extends AlertType
+  object Http5xxPercentThreshold                            extends AlertType
+  object Http5xxThreshold                                   extends AlertType
+  object HttpAbsolutePercentSplitThreshold                  extends AlertType
+  object HttpAbsolutePercentSplitDownstreamHodThreshold     extends AlertType
+  object HttpStatusPercentThreshold                         extends AlertType
+  object HttpStatusThreshold                                extends AlertType
+  object HttpTrafficThreshold                               extends AlertType
+  object LogMessageThreshold                                extends AlertType
+  object MetricsThreshold                                   extends AlertType
+  object TotalHttpRequestThreshold                          extends AlertType
+  object Http90PercentileResponseTimeThreshold              extends AlertType
 }
 
 /** This class determines which standard alerts go where in each environment.
@@ -44,116 +45,123 @@ object GrafanaMigration {
 
   val config = Map(
     Environment.Integration -> Map(
-      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
+      AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold                          -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold              -> AlertingPlatform.Grafana
     ),
     Environment.Development -> Map(
-      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
+      AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold                          -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold              -> AlertingPlatform.Grafana
     ),
     Environment.Qa -> Map(
-      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
+      AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold                          -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold              -> AlertingPlatform.Grafana
     ),
     Environment.Staging -> Map(
-      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
+      AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold                          -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold              -> AlertingPlatform.Grafana
     ),
     Environment.ExternalTest -> Map(
-      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
+      AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Sensu,
+      AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold                          -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold              -> AlertingPlatform.Grafana
     ),
     Environment.Production -> Map(
-      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold                -> AlertingPlatform.Sensu,
-      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                    -> AlertingPlatform.Sensu,
-      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
-      AlertType.Http5xxThreshold                      -> AlertingPlatform.Sensu,
-      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Sensu,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Sensu,
-      AlertType.LogMessageThreshold                   -> AlertingPlatform.Sensu,
-      AlertType.MetricsThreshold                      -> AlertingPlatform.Sensu,
-      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
+      AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                             -> AlertingPlatform.Sensu,
+      AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Sensu,
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Sensu,
+      AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Sensu,
+      AlertType.HttpStatusThreshold                                -> AlertingPlatform.Sensu,
+      AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Sensu,
+      AlertType.LogMessageThreshold                                -> AlertingPlatform.Sensu,
+      AlertType.MetricsThreshold                                   -> AlertingPlatform.Sensu,
+      AlertType.TotalHttpRequestThreshold                          -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold              -> AlertingPlatform.Grafana
     ),
     Environment.Management -> Map(
-      AlertType.AverageCPUThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.ContainerKillThreshold                -> AlertingPlatform.Grafana,
-      AlertType.ErrorsLoggedThreshold                 -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                    -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold               -> AlertingPlatform.Grafana,
-      AlertType.Http5xxThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.HttpAbsolutePercentSplitThreshold     -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusPercentThreshold            -> AlertingPlatform.Grafana,
-      AlertType.HttpStatusThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.HttpTrafficThreshold                  -> AlertingPlatform.Grafana,
-      AlertType.LogMessageThreshold                   -> AlertingPlatform.Grafana,
-      AlertType.MetricsThreshold                      -> AlertingPlatform.Grafana,
-      AlertType.TotalHttpRequestThreshold             -> AlertingPlatform.Grafana,
-      AlertType.Http90PercentileResponseTimeThreshold -> AlertingPlatform.Grafana
+      AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
+      AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Grafana,
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
+      AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
+      AlertType.LogMessageThreshold                                -> AlertingPlatform.Grafana,
+      AlertType.MetricsThreshold                                   -> AlertingPlatform.Grafana,
+      AlertType.TotalHttpRequestThreshold                          -> AlertingPlatform.Grafana,
+      AlertType.Http90PercentileResponseTimeThreshold              -> AlertingPlatform.Grafana
     )
   )
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpAbsolutePercentSplitDownstreamHodThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpAbsolutePercentSplitDownstreamHodThreshold.scala
@@ -26,7 +26,8 @@ case class HttpAbsolutePercentSplitDownstreamHodThreshold(
     excludeSpikes: Int = 0,
     errorFilter: String = "status:>498",
     target: String = "",
-    severity: AlertSeverity = AlertSeverity.Critical
+    severity: AlertSeverity = AlertSeverity.Critical,
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object HttpAbsolutePercentSplitDownstreamHodThresholdProtocol {
@@ -34,7 +35,7 @@ object HttpAbsolutePercentSplitDownstreamHodThresholdProtocol {
 
   implicit val thresholdFormat: JsonFormat[HttpAbsolutePercentSplitDownstreamHodThreshold] = {
     implicit val asf: JsonFormat[AlertSeverity] = alertSeverityFormat
-    jsonFormat8(HttpAbsolutePercentSplitDownstreamHodThreshold)
+    jsonFormat9(HttpAbsolutePercentSplitDownstreamHodThreshold)
   }
 
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -120,16 +120,15 @@ object AlertsYamlBuilder {
       exceptionThreshold = convertExceptionThreshold(alertConfigBuilder.exceptionThreshold, currentEnvironment),
       http5xxPercentThreshold = convertHttp5xxPercentThresholds(alertConfigBuilder.http5xxPercentThreshold, currentEnvironment),
       http5xxThreshold = convertHttp5xxThreshold(alertConfigBuilder.http5xxThreshold, currentEnvironment),
-      httpAbsolutePercentSplitThreshold =
-        convertHttpAbsolutePercentSplitThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitThresholds, currentEnvironment),
+      httpAbsolutePercentSplitThreshold = convertHttpAbsolutePercentSplitThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitThresholds, currentEnvironment),
+      httpAbsolutePercentSplitDownstreamHodThreshold = convertHttpAbsolutePercentSplitDownstreamHodThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitDownstreamHodThresholds, currentEnvironment),
       httpStatusPercentThresholds = convertHttpStatusPercentThresholdAlerts(alertConfigBuilder.httpStatusPercentThresholds, currentEnvironment),
       httpStatusThresholds = convertHttpStatusThresholds(alertConfigBuilder.httpStatusThresholds, currentEnvironment),
       httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds, currentEnvironment),
       logMessageThresholds = convertLogMessageThresholdAlerts(alertConfigBuilder.logMessageThresholds, currentEnvironment),
       totalHttpRequestThreshold = convertTotalHttpRequestThreshold(alertConfigBuilder.totalHttpRequestThreshold, currentEnvironment),
       metricsThresholds = convertMetricsThreshold(alertConfigBuilder.metricsThresholds, currentEnvironment),
-      http90PercentileResponseTimeThreshold =
-        convertHttp90PercentileResponseTimeThreshold(alertConfigBuilder.http90PercentileResponseTimeThresholds, currentEnvironment)
+      http90PercentileResponseTimeThreshold = convertHttp90PercentileResponseTimeThreshold(alertConfigBuilder.http90PercentileResponseTimeThresholds, currentEnvironment)
     )
   }
 
@@ -219,6 +218,29 @@ object AlertsYamlBuilder {
           hysteresis = threshold.hysteresis,
           excludeSpikes = threshold.excludeSpikes,
           errorFilter = threshold.errorFilter,
+          severity = threshold.severity.toString
+        )
+      }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
+  def convertHttpAbsolutePercentSplitDownstreamHodThresholdAlert(httpAbsolutePercentSplitDownstreamHodThresholds: Seq[HttpAbsolutePercentSplitDownstreamHodThreshold],
+                                                                 currentEnvironment: Environment): Option[Seq[YamlHttpAbsolutePercentSplitDownstreamHodThresholdAlert]] = {
+    val converted = httpAbsolutePercentSplitDownstreamHodThresholds
+      .withFilter(alert =>
+        isGrafanaEnabled(
+          alert.alertingPlatform,
+          currentEnvironment,
+          AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold) && alert.absoluteThreshold < Int.MaxValue)
+      .map { threshold =>
+        YamlHttpAbsolutePercentSplitDownstreamHodThresholdAlert(
+          percentThreshold = threshold.percentThreshold,
+          crossover = threshold.crossOver,
+          absoluteThreshold = threshold.absoluteThreshold,
+          hysteresis = threshold.hysteresis,
+          excludeSpikes = threshold.excludeSpikes,
+          errorFilter = threshold.errorFilter,
+          target = threshold.target,
           severity = threshold.severity.toString
         )
       }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
@@ -29,6 +29,7 @@ case class Alerts(
     http5xxThreshold: Option[YamlHttp5xxThresholdAlert] = None,
     http5xxPercentThreshold: Option[YamlHttp5xxPercentThresholdAlert] = None,
     httpAbsolutePercentSplitThreshold: Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = None,
+    httpAbsolutePercentSplitDownstreamHodThreshold: Option[Seq[YamlHttpAbsolutePercentSplitDownstreamHodThresholdAlert]] = None,
     httpStatusPercentThresholds: Option[Seq[YamlHttpStatusPercentThresholdAlert]] = None,
     httpStatusThresholds: Option[Seq[YamlHttpStatusThresholdAlert]] = None,
     httpTrafficThresholds: Option[Seq[YamlHttpTrafficThresholdAlert]] = None,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
@@ -54,6 +54,17 @@ case class YamlHttpAbsolutePercentSplitThresholdAlert(
     severity: String
 )
 
+case class YamlHttpAbsolutePercentSplitDownstreamHodThresholdAlert(
+    percentThreshold: Double,
+    crossover: Int,
+    absoluteThreshold: Int,
+    hysteresis: Double,
+    excludeSpikes: Int,
+    errorFilter: String,
+    target: String,
+    severity: String
+)
+
 case class YamlHttpStatusThresholdAlert(
     count: Int = 1,
     httpMethod: String,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -530,6 +530,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     val target        = "hod-endpoint"
     val severity      = AlertSeverity.Warning
 
+
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttpAbsolutePercentSplitDownstreamHodThreshold(
         HttpAbsolutePercentSplitDownstreamHodThreshold(percent, crossOver, absolute, hysteresis, excludeSpikes, filter, target, severity))
@@ -548,7 +549,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         "excludeSpikes"     -> JsNumber(excludeSpikes),
         "hysteresis"        -> JsNumber(hysteresis),
         "percentThreshold"  -> JsNumber(percent),
-        "severity"          -> JsString("warning")
+        "severity"          -> JsString("warning"),
+        "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
       ))
 
     serviceConfig("absolute-percentage-split-downstream-hod-threshold") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -221,6 +221,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val target     = "hod-endpoint"
       val severity   = AlertSeverity.Warning
 
+
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
         .withHttpAbsolutePercentSplitDownstreamHodThreshold(
@@ -242,7 +243,8 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "excludeSpikes"     -> JsNumber(spikes),
           "hysteresis"        -> JsNumber(hysteresis),
           "percentThreshold"  -> JsNumber(percent),
-          "severity"          -> JsString(severity.toString)
+          "severity"          -> JsString(severity.toString),
+          "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
         ))
 
       service1Config("absolute-percentage-split-downstream-hod-threshold") shouldBe expected


### PR DESCRIPTION
Adds YAML/Grafana export for HttpAbsolutePercentSplitDownstreamHodThreshold alerts

### Before/After of Grafana YAML:
<img width="1793" alt="Screenshot 2024-05-21 at 14 14 45" src="https://github.com/hmrc/alert-config-builder/assets/5603054/9045c29d-884b-4bee-9a64-8209b0bcd72b">

### Before/After of Sensu JSON:
<img width="1801" alt="Screenshot 2024-05-21 at 14 15 10" src="https://github.com/hmrc/alert-config-builder/assets/5603054/66badef0-1a2d-4974-9c02-4178dda67b4b"> 

### Co-Authors
Co-authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>
Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>
