### PR TITLE
TEL-4504 Update heartbeat handler integration name

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilder.scala
@@ -37,11 +37,11 @@ object IntegrationsYamlBuilder {
         // This is a clumsy implementation of adding the INFO status.
         //
         // It must only be added for:
-        // 1. the "team-telemetry-heartbeat" integration
+        // 1. the "team-telemetry-heartbeat-custom" integration
         // 2. in YAML (for Grafana)
         //
         // If we turn it on in Sensu, the entirety of Sensu crashes HARD! see TEL-4404
-        if (builder.integrationName.equals("team-telemetry-heartbeat")) {
+        if (builder.integrationName.equals("team-telemetry-heartbeat-custom")) {
           Integration(
             name = builder.integrationName,
             severitiesEnabled = Seq(Critical, Warning, Info).map(_.toString)


### PR DESCRIPTION
What did we do?
--

1. This was the missing piece of the puzzle that caused the heartbeat alerts to go off, as detailed in [TEL-4569](https://jira.tools.tax.service.gov.uk/browse/TEL-4569)

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4504

Evidence of work
--

1. I tested that this fixes the heartbeat issue, and it does - see notes on TEL-4569. 

Next Steps
--

1. Build this, and then bump alert-config. Ensuring that it is in the same PR as the Alert-Config custom alert changes.

Risks
--

1. Another, unrelated issue presents itself. I plan to mitigate this by deploying Alert-Config off a branch, as well as the Terraform, in order to test alerts still fire as expected, and allow easier rollback.
