### PR TITLE
TEL-4554 Adds support for 'statistic' to Cloudwatch alerts

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
@@ -20,6 +20,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.CloudWatchSource.CloudWatchSource
 import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
 import uk.gov.hmrc.alertconfig.builder.custom.ReducerFunction.ReducerFunction
+import uk.gov.hmrc.alertconfig.builder.custom.Statistic.Statistic
 
 /** CloudWatch metrics based alert.
   *
@@ -53,6 +54,8 @@ import uk.gov.hmrc.alertconfig.builder.custom.ReducerFunction.ReducerFunction
   *   All alerts are prefixed with the team name
   * @param thresholds
   *   Trigger point for each environment
+  * @param statistic
+  *   Used in the query. Valid values include Average, Maximum, Minimum, Sum, SampleCount, IQM
   */
 case class CustomCloudWatchMetricAlert(
     alertName: String,
@@ -69,5 +72,6 @@ case class CustomCloudWatchMetricAlert(
     severity: AlertSeverity,
     summary: String,
     teamName: String,
-    thresholds: EnvironmentThresholds
+    thresholds: EnvironmentThresholds,
+    statistic: Option[Statistic] = Some(Statistic.MAXIMUM),
 ) extends CustomAlert

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/Statistic.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/Statistic.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.custom
+
+object Statistic {
+  type Statistic = String
+
+  val MAXIMUM = "Maximum"
+  val MINIMUM = "Minimum"
+  val AVERAGE   = "Average"
+  val SUM  = "Sum"
+  val SAMPLE_COUNT   = "SampleCount"
+  val IQM   = "IQM"
+}


### PR DESCRIPTION
What did we do?
--

1. Noted that this was hard coded in Cloudwatch alerts. We don't want that.

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4554

Evidence of work
--

n/a

Next Steps
--

1. Update alert-config to use this new feature
2. Update telemetry-grafana-alert-config to use this new feature

Risks
--

1. None known, but ideally should have tests

Collaboration
--

Co-authored by: Ali Bahman <abn@webit4.me>
Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>

