### PR TITLE
TEL-4558 Migrate Http5xxThreshold to Grafana in mdtp-production

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -135,7 +135,7 @@ object GrafanaMigration {
       AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
       AlertType.ExceptionThreshold                                 -> AlertingPlatform.Sensu,
       AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
-      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Sensu,
+      AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Sensu,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -250,7 +250,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         .fields
 
       serviceConfig("5xx-threshold") shouldBe JsObject(
-        "count"            -> JsNumber(2),
+        "count"            -> JsNumber(Int.MaxValue),
         "severity"         -> JsString("critical"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString))
     }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -486,7 +486,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config = configs(0)
       val service2Config = configs(1)
 
-      val expected = JsObject("count" -> JsNumber(threshold), "severity" -> JsString("warning"), "alertingPlatform" -> JsString("Default"))
+      val expected = JsObject("count" -> JsNumber(Int.MaxValue), "severity" -> JsString("warning"), "alertingPlatform" -> JsString("Default"))
 
       service1Config("5xx-threshold") shouldBe expected
       service2Config("5xx-threshold") shouldBe expected


### PR DESCRIPTION
What did we do?
--

1. Migrate **Http5xxThreshold** to **Grafana** in **mdtp-production**

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4558

Evidence of work
--

1.

Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by:
