### PR TITLE
TEL-4602 Adds Grafana support for withHttpAbsolutePercentSplitDownstreamHodThreshold

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -403,7 +403,7 @@ case class AlertConfigBuilder(
              |"log-message-thresholds" : ${logMessageThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).toJson.compactPrint},
              |"average-cpu-threshold" : $updatedAverageCPUThreshold,
              |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
-             |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds)(HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
+             |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold)))(HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
              |"absolute-percentage-split-downstream-hod-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamHodThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold)))(HttpAbsolutePercentSplitDownstreamHodThresholdProtocol.thresholdFormat)}
              |}
               """.stripMargin

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -28,6 +28,7 @@ object AlertType {
   object Http5xxThreshold                                   extends AlertType
   object HttpAbsolutePercentSplitThreshold                  extends AlertType
   object HttpAbsolutePercentSplitDownstreamHodThreshold     extends AlertType
+  object HttpAbsolutePercentSplitDownstreamServiceThreshold extends AlertType
   object HttpStatusPercentThreshold                         extends AlertType
   object HttpStatusThreshold                                extends AlertType
   object HttpTrafficThreshold                               extends AlertType
@@ -53,6 +54,7 @@ object GrafanaMigration {
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
@@ -70,6 +72,7 @@ object GrafanaMigration {
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
@@ -87,6 +90,7 @@ object GrafanaMigration {
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
@@ -104,6 +108,7 @@ object GrafanaMigration {
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
@@ -121,6 +126,7 @@ object GrafanaMigration {
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Sensu,
+      AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,
@@ -139,6 +145,7 @@ object GrafanaMigration {
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Sensu,
+      AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusThreshold                                -> AlertingPlatform.Sensu,
       AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Sensu,
       AlertType.LogMessageThreshold                                -> AlertingPlatform.Grafana,
@@ -155,6 +162,7 @@ object GrafanaMigration {
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold     -> AlertingPlatform.Grafana,
+      AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold -> AlertingPlatform.Sensu,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,
       AlertType.HttpStatusThreshold                                -> AlertingPlatform.Grafana,
       AlertType.HttpTrafficThreshold                               -> AlertingPlatform.Grafana,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpAbsolutePercentSplitDownstreamServiceThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/HttpAbsolutePercentSplitDownstreamServiceThreshold.scala
@@ -26,7 +26,8 @@ case class HttpAbsolutePercentSplitDownstreamServiceThreshold(
     excludeSpikes: Int = 0,
     errorFilter: String = "status:>498",
     target: String = "",
-    severity: AlertSeverity = AlertSeverity.Critical
+    severity: AlertSeverity = AlertSeverity.Critical,
+    alertingPlatform: AlertingPlatform = AlertingPlatform.Default
 )
 
 object HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol {
@@ -34,7 +35,7 @@ object HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol {
 
   implicit val thresholdFormat: JsonFormat[HttpAbsolutePercentSplitDownstreamServiceThreshold] = {
     implicit val asf: JsonFormat[AlertSeverity] = alertSeverityFormat
-    jsonFormat8(HttpAbsolutePercentSplitDownstreamServiceThreshold)
+    jsonFormat9(HttpAbsolutePercentSplitDownstreamServiceThreshold)
   }
 
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -122,6 +122,7 @@ object AlertsYamlBuilder {
       http5xxThreshold = convertHttp5xxThreshold(alertConfigBuilder.http5xxThreshold, currentEnvironment),
       httpAbsolutePercentSplitThreshold = convertHttpAbsolutePercentSplitThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitThresholds, currentEnvironment),
       httpAbsolutePercentSplitDownstreamHodThreshold = convertHttpAbsolutePercentSplitDownstreamHodThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitDownstreamHodThresholds, currentEnvironment),
+      httpAbsolutePercentSplitDownstreamServiceThreshold = convertHttpAbsolutePercentSplitDownstreamServiceThresholdAlert(alertConfigBuilder.httpAbsolutePercentSplitDownstreamServiceThresholds, currentEnvironment),
       httpStatusPercentThresholds = convertHttpStatusPercentThresholdAlerts(alertConfigBuilder.httpStatusPercentThresholds, currentEnvironment),
       httpStatusThresholds = convertHttpStatusThresholds(alertConfigBuilder.httpStatusThresholds, currentEnvironment),
       httpTrafficThresholds = convertHttpTrafficThresholds(alertConfigBuilder.httpTrafficThresholds, currentEnvironment),
@@ -246,6 +247,31 @@ object AlertsYamlBuilder {
       }
     Option.when(converted.nonEmpty)(converted)
   }
+
+
+  def convertHttpAbsolutePercentSplitDownstreamServiceThresholdAlert(httpAbsolutePercentSplitDownstreamServiceThresholds: Seq[HttpAbsolutePercentSplitDownstreamServiceThreshold],
+                                                                 currentEnvironment: Environment): Option[Seq[YamlHttpAbsolutePercentSplitDownstreamServiceThresholdAlert]] = {
+    val converted = httpAbsolutePercentSplitDownstreamServiceThresholds
+      .withFilter(alert =>
+        isGrafanaEnabled(
+          alert.alertingPlatform,
+          currentEnvironment,
+          AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold) && alert.absoluteThreshold < Int.MaxValue)
+      .map { threshold =>
+        YamlHttpAbsolutePercentSplitDownstreamServiceThresholdAlert(
+          percentThreshold = threshold.percentThreshold,
+          crossover = threshold.crossOver,
+          absoluteThreshold = threshold.absoluteThreshold,
+          hysteresis = threshold.hysteresis,
+          excludeSpikes = threshold.excludeSpikes,
+          errorFilter = threshold.errorFilter,
+          target = threshold.target,
+          severity = threshold.severity.toString
+        )
+      }
+    Option.when(converted.nonEmpty)(converted)
+  }
+
 
   def convertHttpStatusThresholds(httpStatusThresholds: Seq[HttpStatusThreshold],
                                   currentEnvironment: Environment): Option[Seq[YamlHttpStatusThresholdAlert]] = {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/Config.scala
@@ -30,6 +30,7 @@ case class Alerts(
     http5xxPercentThreshold: Option[YamlHttp5xxPercentThresholdAlert] = None,
     httpAbsolutePercentSplitThreshold: Option[Seq[YamlHttpAbsolutePercentSplitThresholdAlert]] = None,
     httpAbsolutePercentSplitDownstreamHodThreshold: Option[Seq[YamlHttpAbsolutePercentSplitDownstreamHodThresholdAlert]] = None,
+    httpAbsolutePercentSplitDownstreamServiceThreshold: Option[Seq[YamlHttpAbsolutePercentSplitDownstreamServiceThresholdAlert]] = None,
     httpStatusPercentThresholds: Option[Seq[YamlHttpStatusPercentThresholdAlert]] = None,
     httpStatusThresholds: Option[Seq[YamlHttpStatusThresholdAlert]] = None,
     httpTrafficThresholds: Option[Seq[YamlHttpTrafficThresholdAlert]] = None,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
@@ -65,6 +65,17 @@ case class YamlHttpAbsolutePercentSplitDownstreamHodThresholdAlert(
     severity: String
 )
 
+case class YamlHttpAbsolutePercentSplitDownstreamServiceThresholdAlert(
+    percentThreshold: Double,
+    crossover: Int,
+    absoluteThreshold: Int,
+    hysteresis: Double,
+    excludeSpikes: Int,
+    errorFilter: String,
+    target: String,
+    severity: String
+)
+
 case class YamlHttpStatusThresholdAlert(
     count: Int = 1,
     httpMethod: String,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -472,7 +472,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
         "excludeSpikes"     -> JsNumber(excludeSpikes),
         "hysteresis"        -> JsNumber(hysteresis),
         "percentThreshold"  -> JsNumber(percent),
-        "severity"          -> JsString("warning")
+        "severity"          -> JsString("warning"),
+        "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
       ))
 
     serviceConfig("absolute-percentage-split-downstream-service-threshold") shouldBe expected

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -204,7 +204,8 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
           "excludeSpikes"     -> JsNumber(spikes),
           "hysteresis"        -> JsNumber(hysteresis),
           "percentThreshold"  -> JsNumber(percent),
-          "severity"          -> JsString(severity.toString)
+          "severity"          -> JsString(severity.toString),
+          "alertingPlatform"  -> JsString(AlertingPlatform.Default.toString)
         ))
 
       service1Config("absolute-percentage-split-downstream-service-threshold") shouldBe expected


### PR DESCRIPTION
What did we do?
--

1. Copied what was done in https://github.com/hmrc/alert-config-builder/pull/129

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4602

Evidence of work
--

1. Automated tests

Next Steps
--

1. Copy what was done in https://github.com/hmrc/alert-config/pull/3541/files

Risks
--

None known

Collaboration
--

Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>
