### PR TITLE
TEL-4585 - Add specific check intervals

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CheckIntervalMinutes.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CheckIntervalMinutes.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.custom
+
+object CheckIntervalMinutes {
+  type CheckIntervalMinutes = Int
+
+  val DEFAULT = 2
+  val ONE_MINUTE = 1
+  val TWO_MINUTES = 2
+  val THREE_MINUTES = 3
+  val FIVE_MINUTES = 5
+  val TEN_MINUTES = 10
+  val FIFTEEN_MINUTES = 15
+  val THIRTY_MINUTES = 30
+  val EIGHT_HOURS = 8 * 60
+}
+

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.alertconfig.builder.custom
 
+import uk.gov.hmrc.alertconfig.builder.custom.CheckIntervalMinutes.CheckIntervalMinutes
 import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
 import uk.gov.hmrc.alertconfig.builder.custom.ReducerFunction.ReducerFunction
@@ -26,7 +27,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   * @param alertName
   *   Name that the alert will be created with
   * @param checkIntervalMinutes
-  *   Number of minutes between each check
+  *   Number of minutes between each check. See [[CheckIntervalMinutes]] for supported values
   * @param kibanaDashboardUri
   *   Kibana uri to link to. This should just be the uri path and not include the domain
   * @param integrations
@@ -50,7 +51,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   */
 case class CustomElasticsearchAlert(
     alertName: String,
-    checkIntervalMinutes: Int,
+    checkIntervalMinutes: CheckIntervalMinutes,
     kibanaDashboardUri: Option[String],
     integrations: Seq[String],
     luceneQuery: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.alertconfig.builder.custom
 
+import uk.gov.hmrc.alertconfig.builder.custom.CloudWatchSource.CloudWatchSource
 import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
 import uk.gov.hmrc.alertconfig.builder.custom.ReducerFunction.ReducerFunction
@@ -47,8 +48,6 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   All alerts are prefixed with the team name
   * @param thresholds
   *   Trigger point for each environment
-  * @param timeRangeMinutes
-  *   The number of minutes to look back in the search query e.g. 15 would mean 15m ago to now
   */
 case class CustomElasticsearchAlert(
     alertName: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.alertconfig.builder.custom
 
-import uk.gov.hmrc.alertconfig.builder.custom.CloudWatchSource.CloudWatchSource
 import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
 import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
 import uk.gov.hmrc.alertconfig.builder.custom.ReducerFunction.ReducerFunction


### PR DESCRIPTION
* Added ability to use specific check intervals from a constant to limit options

## Sensu ones:
```
"interval": 60, // 1 Min
"interval": 120, // 2 Min
"interval": 150, // 2.5 Min
"interval": 180, // 3 Min
"interval": 300, // 5 Min
"interval": 600, // 10 Min
"interval": 900, // 15 min 
"interval": 1800, // 30 min
"interval": 28800 // 8 hours
```

Replicated all the above except 2.5 min as that's just weird. It's used by one alert and it's a Telemetry alert so we'll just refactor it. 

Co-authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>