### PR TITLE
TEL-4630 Updates time options for custom alerts

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
@@ -22,7 +22,9 @@ object TimeRangeAsMinutes {
   val DEFAULT = 15
   val ONE_MINUTE = 1
   val TWO_MINUTES = 2
+  val THREE_MINUTES = 3
   val FIVE_MINUTES = 5
+  val SIX_MINUTES = 6
   val TEN_MINUTES = 10
   val FIFTEEN_MINUTES = 15
   val SIXTEEN_MINUTES = 16


### PR DESCRIPTION
What did we do?
--

1. Some alerts also want 3 or 6 minutes, so I added support for those windows. Essentially we generally want an offset of 1min, so 6mins to 1 mins gives a 5 min eval window.

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4630

Evidence of work
--

1. Automated tests
2. Observation of the other repos

Next Steps
--

1. Update my local branch and PRs with this data.

Risks
--

None known

Collaboration
--

Co-authored by: jonnydh <60072280+jonnydh@users.noreply.github.com>
Co-authored by: Rob White <Crumplepang@users.noreply.github.com>
