### PR TITLE
TEL-4617 Add 90 minutes for check interval and time range queries

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CheckIntervalMinutes.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CheckIntervalMinutes.scala
@@ -27,6 +27,7 @@ object CheckIntervalMinutes {
   val TEN_MINUTES = 10
   val FIFTEEN_MINUTES = 15
   val THIRTY_MINUTES = 30
+  val NINETY_MINUTES = 90
   val EIGHT_HOURS = 8 * 60
 }
 

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
@@ -29,6 +29,7 @@ object TimeRangeAsMinutes {
   val TWENTY_MINUTES = 20
   val THIRTY_MINUTES = 30
   val ONE_HOUR = 1 * 60
+  val NINETY_MINUTES = 90
   val TWO_HOURS = 2 * 60
   val TWELVE_HOURS = 12 * 60
   val TWENTY_FOUR_HOURS = 24 * 60


### PR DESCRIPTION
What did we do?
--

1. Add NINETY_MINUTES to both TimeRangeAsMinutes and CheckIntervalMinutes constants 

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4617

Evidence of work
--

1. Code is as described, NINETY_MINUTES is available for check definitions in alert-config

Next Steps
--

1. Roll out and use


Collaboration
--

Co-authored-by: Muhammed Ahmed <ma3574@users.noreply.github.com>
