### PR TITLE
TEL-4628 Accept double for thresholds

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
@@ -18,6 +18,15 @@ package uk.gov.hmrc.alertconfig.builder.custom
 
 import uk.gov.hmrc.alertconfig.builder.Environment
 
+sealed trait ThresholdValue
+case class IntThreshold(value: Int)       extends ThresholdValue
+case class DoubleThreshold(value: Double) extends ThresholdValue
+
+object ThresholdValue {
+  implicit def intToThresholdValue(value: Int): ThresholdValue       = IntThreshold(value)
+  implicit def doubleToThresholdValue(value: Double): ThresholdValue = DoubleThreshold(value)
+}
+
 /** Define thresholds for any environments you want this custom alert to be active in.
   *
   * @param development
@@ -36,13 +45,13 @@ import uk.gov.hmrc.alertconfig.builder.Environment
   *   The threshold for the staging environment.
   */
 case class EnvironmentThresholds(
-    development: Option[Int] = None,
-    externaltest: Option[Int] = None,
-    integration: Option[Int] = None,
-    management: Option[Int] = None,
-    production: Option[Int] = None,
-    qa: Option[Int] = None,
-    staging: Option[Int] = None
+    development: Option[ThresholdValue] = None,
+    externaltest: Option[ThresholdValue] = None,
+    integration: Option[ThresholdValue] = None,
+    management: Option[ThresholdValue] = None,
+    production: Option[ThresholdValue] = None,
+    qa: Option[ThresholdValue] = None,
+    staging: Option[ThresholdValue] = None
 ) {
 
   /** Checks if the given environment has a threshold defined.
@@ -83,6 +92,28 @@ case class EnvironmentThresholds(
     }
   }
 
+  /** Method overloads to accept either Int or Double for each environment threshold */
+  def withDevelopmentThreshold(threshold: ThresholdValue): EnvironmentThresholds =
+    copy(development = Some(threshold))
+
+  def withExternalTestThreshold(threshold: ThresholdValue): EnvironmentThresholds =
+    copy(externaltest = Some(threshold))
+
+  def withIntegrationThreshold(threshold: ThresholdValue): EnvironmentThresholds =
+    copy(integration = Some(threshold))
+
+  def withManagementThreshold(threshold: ThresholdValue): EnvironmentThresholds =
+    copy(management = Some(threshold))
+
+  def withProductionThreshold(threshold: ThresholdValue): EnvironmentThresholds =
+    copy(production = Some(threshold))
+
+  def withQaThreshold(threshold: ThresholdValue): EnvironmentThresholds =
+    copy(qa = Some(threshold))
+
+  def withStagingThreshold(threshold: ThresholdValue): EnvironmentThresholds =
+    copy(staging = Some(threshold))
+
 }
 
 /** Set common threshold for all environments
@@ -92,11 +123,11 @@ object EnvironmentThresholds {
   /** Creates EnvironmentThresholds with the same threshold for all environments.
     *
     * @param threshold
-    *   An integer to be set as the threshold for all seven environments.
+    *   A ThresholdValue to be set as the threshold for all seven environments.
     * @return
     *   EnvironmentThresholds with the same threshold for all environments.
     */
-  def forAllEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
+  def forAllEnvironments(threshold: ThresholdValue): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
     externaltest = Some(threshold),
     staging = Some(threshold),
@@ -109,11 +140,11 @@ object EnvironmentThresholds {
   /** Creates EnvironmentThresholds with the same threshold for production and external test environments.
     *
     * @param threshold
-    *   An integer to be set for the production and external test environments.
+    *   A ThresholdValue to be set for the production and external test environments.
     * @return
     *   EnvironmentThresholds with the same threshold for production and external test environments.
     */
-  def forAllProdEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
+  def forAllProdEnvironments(threshold: ThresholdValue): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
     externaltest = Some(threshold)
   )
@@ -121,11 +152,11 @@ object EnvironmentThresholds {
   /** Creates EnvironmentThresholds with the same threshold for all non-production environments.
     *
     * @param threshold
-    *   An integer to be set as the threshold for all non-production environments.
+    *   A ThresholdValue to be set as the threshold for all non-production environments.
     * @return
     *   EnvironmentThresholds with the same threshold for all non-production environments.
     */
-  def forAllNonProdEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
+  def forAllNonProdEnvironments(threshold: ThresholdValue): EnvironmentThresholds = EnvironmentThresholds(
     staging = Some(threshold),
     qa = Some(threshold),
     development = Some(threshold),

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentThresholdsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentThresholdsSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.custom
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.alertconfig.builder.Environment
+
+class EnvironmentThresholdsSpec extends AnyWordSpec with Matchers {
+
+  "EnvironmentThresholds" should {
+
+    "correctly set thresholds for all non-production environments with Int values" in {
+      val thresholds = EnvironmentThresholds.forAllNonProdEnvironments(9)
+
+      thresholds.development shouldEqual Some(IntThreshold(9))
+      thresholds.externaltest shouldEqual None
+      thresholds.integration shouldEqual Some(IntThreshold(9))
+      thresholds.management shouldEqual Some(IntThreshold(9))
+      thresholds.qa shouldEqual Some(IntThreshold(9))
+      thresholds.staging shouldEqual Some(IntThreshold(9))
+      thresholds.production shouldEqual None
+    }
+
+    "correctly set thresholds for all non-production environments with Double values" in {
+      val thresholds = EnvironmentThresholds.forAllNonProdEnvironments(9.5)
+
+      thresholds.development shouldEqual Some(DoubleThreshold(9.5))
+      thresholds.externaltest shouldEqual None
+      thresholds.integration shouldEqual Some(DoubleThreshold(9.5))
+      thresholds.management shouldEqual Some(DoubleThreshold(9.5))
+      thresholds.qa shouldEqual Some(DoubleThreshold(9.5))
+      thresholds.staging shouldEqual Some(DoubleThreshold(9.5))
+      thresholds.production shouldEqual None
+    }
+
+    "verify that an environment is defined when using Int values" in {
+      val thresholds = EnvironmentThresholds.forAllNonProdEnvironments(9)
+
+      thresholds.isEnvironmentDefined(Environment.Development) shouldEqual true
+      thresholds.isEnvironmentDefined(Environment.Production) shouldEqual false
+    }
+
+    "verify that an environment is defined when using Double values" in {
+      val thresholds = EnvironmentThresholds.forAllNonProdEnvironments(9.5)
+
+      thresholds.isEnvironmentDefined(Environment.Staging) shouldEqual true
+      thresholds.isEnvironmentDefined(Environment.Production) shouldEqual false
+    }
+
+    "remove all other environment thresholds except the specified one" in {
+      val thresholds = EnvironmentThresholds(
+        development = Some(IntThreshold(9)),
+        externaltest = Some(DoubleThreshold(9.5)),
+        integration = Some(IntThreshold(8)),
+        management = Some(DoubleThreshold(8.5)),
+        production = Some(IntThreshold(7)),
+        qa = Some(DoubleThreshold(7.5)),
+        staging = Some(IntThreshold(6))
+      )
+
+      val updatedThresholds = thresholds.removeAllOtherEnvironmentThresholds(Environment.Integration)
+
+      updatedThresholds.development shouldEqual None
+      updatedThresholds.externaltest shouldEqual None
+      updatedThresholds.integration shouldEqual Some(IntThreshold(8))
+      updatedThresholds.management shouldEqual None
+      updatedThresholds.production shouldEqual None
+      updatedThresholds.qa shouldEqual None
+      updatedThresholds.staging shouldEqual None
+    }
+  }
+
+}


### PR DESCRIPTION
What did we do?
--
1. Update Environments Thresholds to receive doubles as well as integers
2. Unit test it

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4628

Evidence of work
--

1. Tested it locally by the alert which is our first use case of double threshold and it renders what expected in yaml, heaven saves us in the Terraform/Grafana land :crossed_fingers: 

![image](https://github.com/hmrc/alert-config-builder/assets/1422984/8dc10b35-5c3e-4dc4-9a09-306443468e9f)


Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by:
