### PR TITLE
TEL-4557 Migrates ExceptionThreshold alert to Grafana in prod

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -139,7 +139,7 @@ object GrafanaMigration {
       AlertType.AverageCPUThreshold                                -> AlertingPlatform.Grafana,
       AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
       AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
-      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Sensu,
+      AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
       AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -43,7 +43,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("app") shouldBe JsString("service1.domain.zone.1")
       config("handlers") shouldBe JsArray(JsString("h1"), JsString("h2"))
       config("exception-threshold") shouldBe JsObject(
-        "count"            -> JsNumber(2),
+        "count"            -> JsNumber(Int.MaxValue),
         "severity"         -> JsString("critical"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
@@ -469,7 +469,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     serviceConfig("handlers") shouldBe expected
   }
 
-  "configure ExceptionThreshold with given thresholds when the alerting platform is Sensu" in {
+  "configure ExceptionThreshold with max integer value when the alerting platform is Sensu" in {
     val threshold = 12
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withExceptionThreshold(threshold)
@@ -481,7 +481,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     val expected = JsObject(
       "severity"         -> JsString("critical"),
-      "count"            -> JsNumber(threshold),
+      "count"            -> JsNumber(Int.MaxValue),
       "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
 
@@ -519,7 +519,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
     val expected = JsObject(
       "severity"         -> JsString("warning"),
-      "count"            -> JsNumber(threshold),
+      "count"            -> JsNumber(Int.MaxValue),
       "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
     )
 

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -299,12 +299,12 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service2Config = configs(1)
 
       service1Config("exception-threshold") shouldBe JsObject(
-        "count"            -> JsNumber(threshold),
+        "count"            -> JsNumber(Int.MaxValue),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("exception-threshold") shouldBe JsObject(
-        "count"            -> JsNumber(threshold),
+        "count"            -> JsNumber(Int.MaxValue),
         "severity"         -> JsString("warning"),
         "alertingPlatform" -> JsString(AlertingPlatform.Default.toString)
       )

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -181,7 +181,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.exceptionThreshold shouldBe None
+      output.exceptionThreshold shouldBe Some(YamlExceptionThresholdAlert(60, "critical"))
     }
 
     "Http5xxPercentThreshold should be enabled if alertingPlatform is Grafana" in {


### PR DESCRIPTION
References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4557

Evidence of work
--

1. Automated tests

Next Steps
--

1. Update alert-config to new version
2. Observe rollout

Risks
--

1. This will put several thousand additional alerts onto Grafana-alerting via Elasticsearch
