### PR TITLE
TEL-4712 Improving naming of parameter

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
@@ -59,7 +59,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   Trigger point for each environment
   * @param statistic
   *   Used in the query. Valid values include Average, Maximum, Minimum, Sum, SampleCount, IQM
- * @param evaluationPeriodMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+ * @param queryTimeRangeMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
   */
 case class CustomCloudWatchMetricAlert(
     alertName: String,
@@ -78,5 +78,5 @@ case class CustomCloudWatchMetricAlert(
     teamName: String,
     thresholds: EnvironmentThresholds,
     statistic: Option[Statistic] = Some(Statistic.MAXIMUM),
-    evaluationPeriodMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
+    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
 ) extends CustomAlert

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
@@ -50,7 +50,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   All alerts are prefixed with the team name
   * @param thresholds
   *   Trigger point for each environment
- * @param evaluationPeriodMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+ * @param queryTimeRangeMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
   */
 case class CustomElasticsearchAlert(
     alertName: String,
@@ -65,5 +65,5 @@ case class CustomElasticsearchAlert(
     summary: String,
     teamName: String,
     thresholds: EnvironmentThresholds,
-    evaluationPeriodMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
+    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
 ) extends CustomAlert

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
@@ -49,7 +49,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   The description to populate in PagerDuty when the alert fires
   * @param thresholds
   *   Trigger point for each environment
- * @param evaluationPeriodMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+ * @param queryTimeRangeMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
   */
 case class CustomGraphiteMetricAlert(
     alertName: String,
@@ -64,5 +64,5 @@ case class CustomGraphiteMetricAlert(
     severity: AlertSeverity,
     summary: String,
     thresholds: EnvironmentThresholds,
-    evaluationPeriodMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
+    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
 ) extends CustomAlert


### PR DESCRIPTION
What did we do?
--

In CustomGraphiteMetricAlert we have the following parameter: evaluationPeriodMinutes

Then in terraform we set the time range using that value

So in grafana land, the terms ‘evaluation interval’ and ‘evaluation group’ refers to how often the check runs

Whereas time_range refers to the time range over which the query will evaluate data.

We have changed `evaluationPeriodMinutes` to `queryTimeRangeMinutes`, so that our terminology better matches that of the Grafana docs.

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4712

Evidence of work
--

1. Tested it with alert-config using sbt buildLocal

Next Steps
--

1. Once built, update alert-config to use new builder, and update param names.
2. Update param names in telemetry-grafana-alert-config

Risks
--

1. I miss something when find and replacing, but in the worst case I will just end up killing the pipeline and will have to fix forward. 
