### PR TITLE
TEL-4529 Puts Http5xxPercentThreshold live on grafana-alerting

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/GrafanaMigration.scala
@@ -146,7 +146,7 @@ object GrafanaMigration {
       AlertType.ContainerKillThreshold                             -> AlertingPlatform.Grafana,
       AlertType.ErrorsLoggedThreshold                              -> AlertingPlatform.Grafana,
       AlertType.ExceptionThreshold                                 -> AlertingPlatform.Grafana,
-      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Sensu, // see TEL-4446 - when we put this live, announce the new feature
+      AlertType.Http5xxPercentThreshold                            -> AlertingPlatform.Grafana,
       AlertType.Http5xxThreshold                                   -> AlertingPlatform.Grafana,
       AlertType.HttpAbsolutePercentSplitThreshold                  -> AlertingPlatform.Grafana,
       AlertType.HttpStatusPercentThreshold                         -> AlertingPlatform.Grafana,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -32,6 +32,8 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   "AlertConfigBuilder" should {
     "build correct config" in {
 
+      val disabledThreshold = 333.33
+
       val config = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
         .withContainerKillThreshold(56)
         .build
@@ -55,7 +57,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
       config("5xx-percent-threshold") shouldBe JsObject(
         "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"                   -> JsNumber(100),
+        "percentage"                   -> JsNumber(disabledThreshold),
         "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
       config("total-http-request-threshold") shouldBe JsNumber(Int.MaxValue)
@@ -484,13 +486,14 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"                     -> JsString("critical"),
       "minimumHttp5xxCountThreshold" -> JsNumber(0),
-      "percentage"                   -> JsNumber(threshold),
+      "percentage"                   -> JsNumber(333.33),
       "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
     )
   }
 
   "configure http5xxPercentThreshold with count and percentage thresholds when the alerting platform is Sensu" in {
     val threshold = 13.3
+    val disabledThreshold = 333.33
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold, 10)
       .build
@@ -502,7 +505,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"                     -> JsString("critical"),
       "minimumHttp5xxCountThreshold" -> JsNumber(10),
-      "percentage"                   -> JsNumber(threshold),
+      "percentage"                   -> JsNumber(disabledThreshold),
       "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
     )
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -475,6 +475,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
 
   "configure http5xxPercentThreshold with given thresholds when the alerting platform is Sensu" in {
     val threshold = 13.3
+    val disabledThreshold = 333.33
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold)
       .build
@@ -486,7 +487,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     serviceConfig("5xx-percent-threshold") shouldBe JsObject(
       "severity"                     -> JsString("critical"),
       "minimumHttp5xxCountThreshold" -> JsNumber(0),
-      "percentage"                   -> JsNumber(333.33),
+      "percentage"                   -> JsNumber(disabledThreshold),
       "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
     )
   }

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -235,6 +235,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
         .withHttp5xxPercentThreshold(threshold)
+      val thresholdDisabled = 333.33
 
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
       val configs = alertConfigBuilder.build.map(_.build.get.parseJson.asJsObject.fields)
@@ -246,13 +247,13 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       service1Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"                   -> JsNumber(threshold),
+        "percentage"                   -> JsNumber(thresholdDisabled),
         "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
       service2Config("5xx-percent-threshold") shouldBe JsObject(
         "severity"                     -> JsString("critical"),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
-        "percentage"                   -> JsNumber(threshold),
+        "percentage"                   -> JsNumber(thresholdDisabled),
         "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
       )
     }
@@ -670,6 +671,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct withHttp5xxPercentThreshold" in {
+      val thresholdDisabled = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
@@ -681,7 +683,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"                   -> JsNumber(12.2),
+        "percentage"                   -> JsNumber(thresholdDisabled),
         "minimumHttp5xxCountThreshold" -> JsNumber(0),
         "severity"                     -> JsString("warning"),
         "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)
@@ -689,6 +691,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
     }
 
     "return TeamAlertConfigBuilder with correct withHttp5xxPercentThreshold using optional minimum 5xx count" in {
+      val thresholdDisabled = 333.33
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1"))
         .withLogMessageThreshold("SIMULATED_ERROR1", 19, lessThanMode = false)
@@ -700,7 +703,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val service1Config: Map[String, JsValue] = configs(0)
 
       service1Config("5xx-percent-threshold") shouldBe JsObject(
-        "percentage"                   -> JsNumber(12.2),
+        "percentage"                   -> JsNumber(thresholdDisabled),
         "minimumHttp5xxCountThreshold" -> JsNumber(15),
         "severity"                     -> JsString("warning"),
         "alertingPlatform"             -> JsString(AlertingPlatform.Default.toString)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/MigrationTests.scala
@@ -225,7 +225,7 @@ class MigrationTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
       val output = AlertsYamlBuilder.convertAlerts(config, Environment.Production)
 
-      output.http5xxPercentThreshold shouldBe None
+      output.http5xxPercentThreshold shouldBe Some(YamlHttp5xxPercentThresholdAlert(60.0, 0, "critical"))
     }
 
     "Http5xxThreshold should be enabled if alertingPlatform is Grafana" in {


### PR DESCRIPTION
What did we do?
--

1. Put Http5xxPercentThreshold live on grafana-alerting
2. Updated tests

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4529

Evidence of work
--

1. Automated tests

Next Steps
--

1. Update alert-config
2. Observe rollout
3. Announce

Risks
--

None known

Collaboration
--

Co-authored by: Ali Bahman <abn@webit4.me>
Co-authored-by: Damon Wright
