### PR TITLE
TEL-4699 change pendingPeriodMinutes from Option[Int] to Int

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
@@ -25,8 +25,6 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *
   * @param alertName
   *   Name that the alert will be created with
-  * @param pendingPeriodMinutes
-  *   Amount of time in minutes that a threshold needs to be breached before the alert fires
   * @param dashboardUri
   *   Grafana uri to link to. This should just be the uri path and not include the domain
   * @param dashboardPanelId
@@ -51,11 +49,13 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   The description to populate in PagerDuty when the alert fires
   * @param thresholds
   *   Trigger point for each environment
- * @param queryTimeRangeMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+  * @param pendingPeriodMinutes
+  *   Amount of time in minutes that a threshold needs to be breached before the alert fires
+  * @param queryTimeRangeMinutes 
+  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
   */
 case class CustomGraphiteMetricAlert(
     alertName: String,
-    pendingPeriodMinutes: Option[Int] = None,
     dashboardUri: Option[String],
     dashboardPanelId: Option[Int],
     integrations: Seq[String],
@@ -67,5 +67,6 @@ case class CustomGraphiteMetricAlert(
     severity: AlertSeverity,
     summary: String,
     thresholds: EnvironmentThresholds,
+    pendingPeriodMinutes: Int = None,
     queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
 ) extends CustomAlert


### PR DESCRIPTION
To fix:

```
[AWS CodeBuild Plugin] [info] compiling 153 Scala sources to /codebuild/output/src3992568989/src/github.com/hmrc/alert-config/target/scala-2.13/classes ...
[AWS CodeBuild Plugin] [error] /codebuild/output/src3992568989/src/github.com/hmrc/alert-config/src/main/scala/uk/gov/hmrc/alertconfig/custom/alerts/Telemetry.scala:297:49: type mismatch;
[AWS CodeBuild Plugin] [error]  found   : Int
[AWS CodeBuild Plugin] [error]  required: Option[Int]
[AWS CodeBuild Plugin] [error]       pendingPeriodMinutes = TimeRangeAsMinutes.ONE_HOUR,
[AWS CodeBuild Plugin] [error]                                                 ^
[AWS CodeBuild Plugin] [error] /codebuild/output/src3992568989/src/github.com/hmrc/alert-config/src/main/scala/uk/gov/hmrc/alertconfig/custom/alerts/Telemetry.scala:313:49: type mismatch;
[AWS CodeBuild Plugin] [error]  found   : Int
[AWS CodeBuild Plugin] [error]  required: Option[Int]
[AWS CodeBuild Plugin] [error]       pendingPeriodMinutes = TimeRangeAsMinutes.ONE_HOUR,
[AWS CodeBuild Plugin] [error]      
```
