### PR TITLE
Only flatten severities for current integration

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -68,7 +68,7 @@ object AlertsYamlBuilder {
   }
 
   def removeUnusedAlerts(alertConfigBuilder: AlertConfigBuilder, integrationSeveritiesForEnv: Map[String, Set[Severity]]): AlertConfigBuilder = {
-    val uniqueEnabledSeveritiesForServiceInEnv = integrationSeveritiesForEnv.values.flatten.toSet
+    val uniqueEnabledSeveritiesForServiceInEnv = integrationSeveritiesForEnv.view.filterKeys(alertConfigBuilder.integrations.contains).values.flatten.toSet
     if (uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Critical) && !uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning)) {
       removeUnusedAlerts(alertConfigBuilder, AlertSeverity.Warning)
     } else if (uniqueEnabledSeveritiesForServiceInEnv.contains(Severity.Warning) && !uniqueEnabledSeveritiesForServiceInEnv.contains(


### PR DESCRIPTION
What did we do?
--

1. Changed the discovery of severities to only include ones that the integration supports

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4686

Evidence of work
--

1. Before
```
  - service: p800-refunds-frontend
    alerts:
      ...
      httpTrafficThresholds:
        - count: 50
          maxMinutesBelowThreshold: 5
          severity: warning
        - count: 10
          maxMinutesBelowThreshold: 5
          severity: critical
      http90PercentileResponseTimeThreshold:
        - timePeriod: 15
          count: 1000
          severity: warning
        - timePeriod: 15
          count: 2500
          severity: critical
    pagerduty:
      - integrationKeyName: payments
      - integrationKeyName: payments-oceans-8
```
3. After
```
  - service: p800-refunds-frontend
    alerts:
      ...
      httpTrafficThresholds:
        - count: 10
          maxMinutesBelowThreshold: 5
          severity: critical
      http90PercentileResponseTimeThreshold:
        - timePeriod: 15
          count: 2500
          severity: critical
    pagerduty:
      - integrationKeyName: payments
      - integrationKeyName: payments-oceans-8
```
Next Steps
--

1. Roll out changes

Risks
--

1. Low, only differences in generated service files remove the expected warning levels
```
❯ diff target/output/services.yml target/output/services-new.yml
33235,33237d33234
<         - count: 50
<           maxMinutesBelowThreshold: 5
<           severity: warning
33242,33244d33238
<         - timePeriod: 15
<           count: 1000
<           severity: warning
33297,33299d33290
<         - count: 50
<           maxMinutesBelowThreshold: 5
<           severity: warning
33305,33307d33295
<           count: 1000
<           severity: warning
<         - timePeriod: 15
```

Collaboration
--

Co-authored-by: @gavD 
