### PR TITLE
TEL-4722 Ensures users have to explicitly enable production

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ you can do a local build:
 
 
 1. Do an `sbt publishLocal` to publish a snapshot (https://www.scala-sbt.org/1.x/docs/Publishing.html)
-2. Configure alert-config's `AppDepedencies` to reference your snapshot:
+2. Configure your local `alert-config` project's `AppDepedencies` to reference your snapshot:
 ```scala
   val compile: Seq[ModuleID] = Seq(
-      // "uk.gov.hmrc" %% "alert-config-builder" % "1.112.0"
-      "uk.gov.hmrc" %% "alert-config-builder" % "1.113.0-SNAPSHOT"
+      // "uk.gov.hmrc" %% "alert-config-builder" % "1.112.0"       // comment out the main stream version of alert-config-builder
+      "uk.gov.hmrc" %% "alert-config-builder" % "1.113.0-SNAPSHOT" // your specific snapshot number will vary
   )
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you want to build a local version of alert-config-builder and test it without
 you can do a local build:
 
 
-1. Do an `sbt publishLocal` to publish a snapshot (https://www.scala-sbt.org/1.x/docs/Publishing.html)
+1. Do an `sbt publishLocal` in your `alert-config-builder` folder to publish a snapshot (https://www.scala-sbt.org/1.x/docs/Publishing.html)
 2. Configure your local `alert-config` project's `AppDepedencies` to reference your snapshot:
 ```scala
   val compile: Seq[ModuleID] = Seq(

--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ you can do a local build:
 
 _Note that this is just for local testing - please do not try to commit this change!_
 
-
-NEW
-
-16:30
-Patch versions totally okay, think I did that more frequently than buildLocal when on Platops :shrug:
-
 ### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ We encourage contributors to make sure their work is well formatted using the fo
 
 [Visit the official Scalafmt documentation to view a complete list of tasks which can be run.](https://scalameta.org/scalafmt/docs/installation.html#task-keys)
 
+## Local testing
+
+If you want to build a local version of alert-config-builder and test it without doing a build of alert-config,
+you can do a local build:
+
+
+1. Do an `sbt publishLocal` (https://www.scala-sbt.org/1.x/docs/Publishing.html)
+2. Configure alert-config's 
+
+
+NEW
+
+16:30
+Patch versions totally okay, think I did that more frequently than buildLocal when on Platops :shrug:
+
 ### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ you can do a local build:
 
 
 1. Do an `sbt publishLocal` in your `alert-config-builder` folder to publish a snapshot (https://www.scala-sbt.org/1.x/docs/Publishing.html)
-2. Configure your local `alert-config` project's `AppDepedencies` to reference your snapshot:
+2. Configure your local `alert-config` project's `AppDependencies` to reference your snapshot:
 ```scala
   val compile: Seq[ModuleID] = Seq(
       // "uk.gov.hmrc" %% "alert-config-builder" % "1.112.0"       // comment out the main stream version of alert-config-builder

--- a/README.md
+++ b/README.md
@@ -52,8 +52,16 @@ If you want to build a local version of alert-config-builder and test it without
 you can do a local build:
 
 
-1. Do an `sbt publishLocal` (https://www.scala-sbt.org/1.x/docs/Publishing.html)
-2. Configure alert-config's 
+1. Do an `sbt publishLocal` to publish a snapshot (https://www.scala-sbt.org/1.x/docs/Publishing.html)
+2. Configure alert-config's `AppDepedencies` to reference your snapshot:
+```scala
+  val compile: Seq[ModuleID] = Seq(
+      // "uk.gov.hmrc" %% "alert-config-builder" % "1.112.0"
+      "uk.gov.hmrc" %% "alert-config-builder" % "1.113.0-SNAPSHOT"
+  )
+```
+
+_Note that this is just for local testing - please do not try to commit this change!_
 
 
 NEW

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfig.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.alertconfig.builder
 trait AlertConfig {
   def alertConfig: Seq[AlertConfigBuilder]
 
-  def environmentConfig: Seq[EnvironmentAlertBuilder] = alertConfig.flatMap(_.integrations).map(EnvironmentAlertBuilder(_))
+  // empty by default to force override
+  def environmentConfig: Seq[EnvironmentAlertBuilder]
 
   implicit def teamAlertConfigToAlertConfigs(config: TeamAlertConfigBuilder): Seq[AlertConfigBuilder] = config.build
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilder.scala
@@ -77,9 +77,9 @@ object AllEnvironmentAlertConfigBuilder {
 case class EnvironmentAlertBuilder(
     integrationName: String,
     command: Option[JsValue] = None,
-    enabledEnvironments: Map[Environment, Set[Severity]] = Map((Environment.Production, Set(Severity.Ok, Severity.Warning, Severity.Critical))),
-    customEnvironmentNames: Map[Environment, String] = Map((Environment.Production, "aws_production")),
-    integrationFilters: Map[Environment, JsValue] = Map((Environment.Production, JsString("occurrences")))
+    enabledEnvironments: Map[Environment, Set[Severity]] = Map(),
+    customEnvironmentNames: Map[Environment, String] = Map(),
+    integrationFilters: Map[Environment, JsValue] = Map()
 ) {
 
   private val defaultSeverities: Set[Severity] = Set(Severity.Ok, Severity.Warning, Severity.Critical)
@@ -162,9 +162,6 @@ case class EnvironmentAlertBuilder(
       customEnvironmentNames = customEnvironmentNames + (Environment.Production -> customEnv),
       integrationFilters = integrationFilters + (Environment.Production         -> customFilter)
     )
-
-  def disableProduction(): EnvironmentAlertBuilder =
-    this.copy(enabledEnvironments = enabledEnvironments - Environment.Production)
 
   def withCommand(customCommand: String): EnvironmentAlertBuilder =
     this.copy(command = Option(JsString(customCommand)))

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -56,7 +56,7 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
 
   test("create config for production") {
     val environmentConfigMap =
-      AllEnvironmentAlertConfigBuilder.build(Set(EnvironmentAlertBuilder("team-telemetry"), EnvironmentAlertBuilder("infra")))
+      AllEnvironmentAlertConfigBuilder.build(Set(EnvironmentAlertBuilder("team-telemetry").inProduction(), EnvironmentAlertBuilder("infra").inProduction()))
 
     environmentConfigMap(Environment.Production) shouldBe
       JsObject(

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/EnvironmentAlertBuilderSpec.scala
@@ -24,8 +24,8 @@ import spray.json._
 class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
 
   "EnvironmentAlertBuilder" should {
-    "create config with production enabled by default" in {
-      EnvironmentAlertBuilder("team-telemetry").alertConfigFor(Environment.Production) shouldBe
+    "create config with production enabled" in {
+      EnvironmentAlertBuilder("team-telemetry").inProduction().alertConfigFor(Environment.Production) shouldBe
         "team-telemetry" ->
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/hmrc_pagerduty_multiteam_env_apiv2.rb --team team-telemetry -e aws_production"),
@@ -35,8 +35,8 @@ class EnvironmentAlertBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         )
     }
 
-    "create config with production disabled" in {
-      EnvironmentAlertBuilder("team-telemetry").disableProduction().alertConfigFor(Environment.Production) shouldBe
+    "create config without production enabled" in {
+      EnvironmentAlertBuilder("team-telemetry").alertConfigFor(Environment.Production) shouldBe
         "team-telemetry" ->
         JsObject(
           "command"    -> JsString("/etc/sensu/handlers/noop.rb"),

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/IntegrationsYamlBuilderSpec.scala
@@ -43,7 +43,7 @@ class IntegrationsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeA
         EnvironmentAlertBuilder("team-telemetry-warning-only").inProduction(Set(Severity.Warning)),
         EnvironmentAlertBuilder("team-telemetry-critical-only").inProduction(Set(Severity.Critical)),
         // This one should not appear in the output YAML
-        EnvironmentAlertBuilder("team-telemetry-non-prod-one").disableProduction().inIntegration(Set(Severity.Warning, Severity.Critical))
+        EnvironmentAlertBuilder("team-telemetry-non-prod-one").inIntegration(Set(Severity.Warning, Severity.Critical))
       )
       IntegrationsYamlBuilder.generate(environmentAlertBuilders, currentEnvironment, testFile)
 


### PR DESCRIPTION
What did we do?
--

1. Ensured you have to explicitly enable production
2. Adds documentation for local testing of `alert-config-builder` + `alert-config` changes
3. Forces overriding of `AlertConfig.environmentConfig` so that if you don't specify and envs, it will crash

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4722

Evidence of work
--

1. Gimmicked local `alert-config` to use this branch
2. Generated services.yml locally with old and new versions of alert-config-builder
3. **Asserted that** where no environment config was present, the builder crashed:
```
[error] /Users/gavin/Code/telemetry/alert-config/src/main/scala/uk/gov/hmrc/alertconfig/configs/DASSSDLTFiling.scala:11:8: object creation impossible.
[error] Missing implementation for member of trait AlertConfig:
[error]   def environmentConfig: Seq[uk.gov.hmrc.alertconfig.builder.EnvironmentAlertBuilder] = ???
[error] object DASSSDLTFiling extends AlertConfig {
[error]        ^
[error] two errors found
[error] (Compile / compileIncremental) Compilation failed
```
4. Resolve these errors and ran alert-config with local build of alert-config-builder
5. Diff'd the results
6. **Asserted that** it does not differ EXCEPT where the existing code is erroneous

> We noted a number of instances whereby users had small misconfigurations, such as:
> 
> ![image](https://github.com/user-attachments/assets/4618ce95-83fd-4a19-a1b4-d7df29007692)
> 
> These were resolved in  https://github.com/hmrc/alert-config/pull/3808

*Finding these faults also proves the value of this change* :-) 

The only difference in production services.yml between that generated right now and the updated version is a single CIP error, which the new version fixes:

<img width="858" alt="image" src="https://github.com/user-attachments/assets/86e0496a-c41d-4286-8e25-0743666322dc">

services.yml deltas for all envs : 

Env | Diff result
-- | --
Production | ✅ New version fixes a problem with a CIP alert
Externaltest | ✅ No-op
Staging | ✅ New version fixes a problem in `DASSPortalAPIAndDBTest`
QA | ✅ No-op
Development | ✅ No-op
Integration | ✅ No-op

Next Steps
--

1. Update alert-config repo PR https://github.com/hmrc/alert-config/pull/3807 with the necessary changes. _That PR is currently broken, waiting for this to be merged, but you can see the changes I propose therein_

Risks
--

1. This is a very large change. We have to be careful not to change alert behaviour
    a. My testing will catch all such errors in production by diff'ing the generated `services.yml` to that built with existing alert-config-builder.
2. Do we need to do anything for custom alerts at this time?

Collaboration
--

Co-authored by: @ma3574 Muhammed Ahmed <ma3574@users.noreply.github.com>
Co-authored by: @alextcap <alex.tasioulis@users.noreply.github.com>
