### PR TITLE
TEL-4722 Throws an exception if an alert has no target envs

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -40,6 +40,9 @@ object AlertsYamlBuilder {
   }
 
   def convert(alertConfig: AlertConfig, currentEnvironment: Environment): Seq[ServiceConfig] = {
+    if(alertConfig.environmentConfig.filter(_.enabledEnvironments.nonEmpty).isEmpty) {
+      throw new Exception("No environments defined for integration " + alertConfig.toString)
+    }
     val filtered                 = alertConfig.environmentConfig.filter(_.enabledEnvironments.contains(currentEnvironment))
     val enabledIntegrationsInEnv = filtered.map(_.integrationName).toSet
     val integrationSeveritiesForEnv = filtered

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -41,7 +41,7 @@ object AlertsYamlBuilder {
 
   def convert(alertConfig: AlertConfig, currentEnvironment: Environment): Seq[ServiceConfig] = {
     if(alertConfig.environmentConfig.filter(_.enabledEnvironments.nonEmpty).isEmpty) {
-      throw new Exception("No environments defined for alert config " + alertConfig.toString)
+      throw new IllegalStateException("No environments defined for alert config " + alertConfig.toString)
     }
     val filtered                 = alertConfig.environmentConfig.filter(_.enabledEnvironments.contains(currentEnvironment))
     val enabledIntegrationsInEnv = filtered.map(_.integrationName).toSet

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -41,7 +41,7 @@ object AlertsYamlBuilder {
 
   def convert(alertConfig: AlertConfig, currentEnvironment: Environment): Seq[ServiceConfig] = {
     if(alertConfig.environmentConfig.filter(_.enabledEnvironments.nonEmpty).isEmpty) {
-      throw new Exception("No environments defined for integration " + alertConfig.toString)
+      throw new Exception("No environments defined for alert config " + alertConfig.toString)
     }
     val filtered                 = alertConfig.environmentConfig.filter(_.enabledEnvironments.contains(currentEnvironment))
     val enabledIntegrationsInEnv = filtered.map(_.integrationName).toSet

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -57,7 +57,7 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
         override def environmentConfig: Seq[EnvironmentAlertBuilder] = Seq[EnvironmentAlertBuilder]()
       }
 
-      intercept[Exception] {
+      intercept[IllegalStateException] {
         AlertsYamlBuilder.convert(
           config,
           currentEnvironment = Environment.Production,

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.alertconfig.builder.yaml
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.alertconfig.builder.TeamAlertConfigBuilder.teamAlerts
 import uk.gov.hmrc.alertconfig.builder._
 
 class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach {
@@ -47,6 +48,21 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
       )
 
       res shouldBe None
+    }
+
+    "throw an exception if there are no envs configured" in {
+      val config = new AlertConfig {
+        override def alertConfig: Seq[AlertConfigBuilder] = teamAlerts(Seq("alert-simulator"))
+
+        override def environmentConfig: Seq[EnvironmentAlertBuilder] = Seq[EnvironmentAlertBuilder]()
+      }
+
+      intercept[Exception] {
+        AlertsYamlBuilder.convert(
+          config,
+          currentEnvironment = Environment.Production,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4722
[thread|https://hmrcdigital.slack.com/archives/CGE0ECS3H/p1723466099311839?thread_ts=1723460407.097429&cid=CGE0ECS3H]

Evidence of work
--

1. ✅ Automated test
2. ✅ Manual test:
    a. Gimmicked alert-config locally to use this version of the builder
    b.  Commented out all the target envs for alert simulator
    b. **Asserted that** the error was thrown

![image](https://github.com/user-attachments/assets/b5365371-63ab-4dc6-921c-5dfa51a58f4d)

![Uploading image.png…]()

Next Steps
--

1. Get the alert-config PR merged https://github.com/hmrc/alert-config/pull/3807

Risks
--

1. Maybe this isn't the most Scalariffic way to do it
    a. ... but I'm confident it works

Collaboration
--

Co-authored by: @ma3574 Muhammed Ahmed [ma3574@users.noreply.github.com](mailto:ma3574@users.noreply.github.com)
Co-authored by: @alextcap [alex.tasioulis@users.noreply.github.com](mailto:alex.tasioulis@users.noreply.github.com)
