### PR TITLE
TEL-4744 make checkIntervalMinutes consistent

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
@@ -54,7 +54,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   */
 case class CustomElasticsearchAlert(
     alertName: String,
-    checkIntervalMinutes: CheckIntervalMinutes,
+    checkIntervalMinutes: Option[CheckIntervalMinutes] = None,
     kibanaDashboardUri: Option[String],
     integrations: Seq[String],
     luceneQuery: String,


### PR DESCRIPTION
What did we do?
--

1. update CustomElasticsearchAlert to match behaviour of CustomGraphiteMetricAlert - checkIntervalMinutes should default to 2 minutes as almost all checks will use this behaviour

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4744
