### PR TITLE
TEL-4771 remove management from the list of all environments

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
@@ -92,7 +92,7 @@ object EnvironmentThresholds {
   /** Creates EnvironmentThresholds with the same threshold for all environments.
     *
     * @param threshold
-    *   An integer to be set as the threshold for all seven environments.
+    *   An integer to be set as the threshold for all six environments.
     * @return
     *   EnvironmentThresholds with the same threshold for all environments.
     */
@@ -102,8 +102,7 @@ object EnvironmentThresholds {
     staging = Some(threshold),
     qa = Some(threshold),
     development = Some(threshold),
-    integration = Some(threshold),
-    management = Some(threshold)
+    integration = Some(threshold)
   )
 
   /** Creates EnvironmentThresholds with the same threshold for production and external test environments.
@@ -126,6 +125,22 @@ object EnvironmentThresholds {
     *   EnvironmentThresholds with the same threshold for all non-production environments.
     */
   def forAllNonProdEnvironments(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
+    staging = Some(threshold),
+    qa = Some(threshold),
+    development = Some(threshold),
+    integration = Some(threshold)
+  )
+
+  /** Creates EnvironmentThresholds with the same threshold for all environments including management.
+   *
+   * @param threshold
+   * An integer to be set as the threshold for all seven environments including management.
+   * @return
+   * EnvironmentThresholds with the same threshold for all environments.
+   */
+  def forAllEnvironmentsPlusManagement(threshold: Int): EnvironmentThresholds = EnvironmentThresholds(
+    production = Some(threshold),
+    externaltest = Some(threshold),
     staging = Some(threshold),
     qa = Some(threshold),
     development = Some(threshold),


### PR DESCRIPTION
What did we do?
--

1. Removed management from the list of all environments, as nothing gets deployed to management and in sensu we have almost no alerts in management
2. Created a new list of environments which we can use for those telemetry checks which are deployed in all environments including management

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4771

Evidence of work
--

1. YOLO

Next Steps
--

1. Update already migrated custom alerts which need to be run in management to use the new forAllEnvironmentsPlusManagement

Risks
--

1. We accidentally disable an alert which is needed in management

