### PR TITLE
add pendingPeriodMinutes to elasticsearch alerts

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
@@ -28,6 +28,8 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   Name that the alert will be created with
   * @param checkIntervalMinutes
   *   Number of minutes between each check. See [[CheckIntervalMinutes]] for supported values
+  * @param pendingPeriodMinutes
+  *   Amount of time in minutes that a threshold needs to be breached before the alert fires
   * @param kibanaDashboardUri
   *   Kibana uri to link to. This should just be the uri path and not include the domain
   * @param integrations
@@ -55,6 +57,7 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
 case class CustomElasticsearchAlert(
     alertName: String,
     checkIntervalMinutes: Option[CheckIntervalMinutes] = None,
+    pendingPeriodMinutes: Option[Int] = None,
     kibanaDashboardUri: Option[String],
     integrations: Seq[String],
     luceneQuery: String,


### PR DESCRIPTION
What did we do?
--

1. Added pendingPeriodMinutes to elasticsearch alerts because alerts like this have "occurrences" defined: https://github.com/hmrc/aws-ami-telemetry-sensu/blob/95d50378cdef94a06612cbd11781d06cd3957237/files/sensu/conf.d/checks/ddcnos_api_platform_state_pension_503_count.json#L10

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4782

