### PR TITLE
add capability for setting Cloudwatch metrics period for Cloudwatch a…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
@@ -59,7 +59,10 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   Trigger point for each environment
   * @param statistic
   *   Used in the query. Valid values include Average, Maximum, Minimum, Sum, SampleCount, IQM
- * @param queryTimeRangeMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+  * @param queryTimeRangeMinutes 
+  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+  * @param period
+  *   CloudWatch metric statistics period
   */
 case class CustomCloudWatchMetricAlert(
     alertName: String,
@@ -78,5 +81,6 @@ case class CustomCloudWatchMetricAlert(
     teamName: String,
     thresholds: EnvironmentThresholds,
     statistic: Option[Statistic] = Some(Statistic.MAXIMUM),
-    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
+    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES,
+    period: TimeRangeAsMinutes = TimeRangeAsMinutes.ONE_MINUTE
 ) extends CustomAlert


### PR DESCRIPTION
…lerts

What did we do?
--

1. Added capability for setting Period. This is used here https://github.com/hmrc/aws-ami-confluence/blob/50940e56c0a6c5d0074d41707ab028d76d28b495/files/etc/sensu/plugins/ddcops_check-cloudwatch-metric.rb#L199-L204

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4784


Next Steps
--

1. Check that we can pass in the period parameter from alert-config

Risks
--

1. We cannot pass in the period parameter and we have to revisit this

Collaboration
--

Co-authored-by: @gavD 
