### PR TITLE
change EnvironmentThresholds from Option[Int] to Option[Long]

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
@@ -36,13 +36,13 @@ import uk.gov.hmrc.alertconfig.builder.Environment
   *   The threshold for the staging environment.
   */
 case class EnvironmentThresholds(
-    development: Option[Int] = None,
-    externaltest: Option[Int] = None,
-    integration: Option[Int] = None,
-    management: Option[Int] = None,
-    production: Option[Int] = None,
-    qa: Option[Int] = None,
-    staging: Option[Int] = None
+    development: Option[Long] = None,
+    externaltest: Option[Long] = None,
+    integration: Option[Long] = None,
+    management: Option[Long] = None,
+    production: Option[Long] = None,
+    qa: Option[Long] = None,
+    staging: Option[Long] = None
 ) {
 
   /** Checks if the given environment has a threshold defined.


### PR DESCRIPTION
What did we do?
--

1. Changed EnvironmentThresholds from Option[Int] to Option[Long]. I did this because here https://github.com/hmrc/aws-ami-telemetry-sensu/blob/35410a6bdb15027eb405eb7b1d52e4eb8bc447a5/files/sensu/conf.d/checks/ddcops_deskpro_rds_free_memory.json#L4C150-L4C160 I need to use a big number and it doesn't fit in Int 😭 

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4784


Next Steps
--

1. Check what happens with alert-config

Risks
--

1. A bunch of stuff breaks because it doesn't like the new type and we need to update type in a bunch of places

Collaboration
--

Co-authored-by: @gavD 
