### PR TITLE
TEL-4784 scala fmt all & fix issue with yaml output showing e.g. "value: 9" instead of "9" after latest merge

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -378,21 +378,48 @@ case class AlertConfigBuilder(
              |"app": "$serviceName.$serviceDomain",
              |"handlers": ${integrations.toJson.compactPrint},
              |"errors-logged-threshold":$updatedErrorsLoggedThreshold,
-             |"exception-threshold":${exceptionThreshold.copy(count = updatedExceptionThreshold).toJson(ExceptionThresholdProtocol.thresholdFormat).compactPrint},
+             |"exception-threshold":${exceptionThreshold
+            .copy(count = updatedExceptionThreshold)
+            .toJson(ExceptionThresholdProtocol.thresholdFormat)
+            .compactPrint},
              |"5xx-threshold":${http5xxThreshold.copy(count = updated5xxThreshold).toJson(Http5xxThresholdProtocol.thresholdFormat).compactPrint},
-             |"5xx-percent-threshold":${http5xxPercentThreshold.copy(percentage = updated5xxPercentThreshold).toJson(Http5xxPercentThresholdProtocol.thresholdFormat).compactPrint},
+             |"5xx-percent-threshold":${http5xxPercentThreshold
+            .copy(percentage = updated5xxPercentThreshold)
+            .toJson(Http5xxPercentThresholdProtocol.thresholdFormat)
+            .compactPrint},
              |"containerKillThreshold" : $updatedContainerKillThreshold,
-             |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption.map(_.toJson.compactPrint).getOrElse(JsNull)},
-             |"httpTrafficThresholds" : ${httpTrafficThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold)).toJson.compactPrint},
-             |"httpStatusThresholds" : ${httpStatusThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold)).toJson.compactPrint},
-             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold)).toJson.compactPrint},
-             |"metricsThresholds" : ${printSeq(metricsThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)))(MetricsThresholdProtocol.thresholdFormat)},
+             |"http90PercentileResponseTimeThresholds" : ${http90PercentileResponseTimeThresholds.headOption
+            .map(_.toJson.compactPrint)
+            .getOrElse(JsNull)},
+             |"httpTrafficThresholds" : ${httpTrafficThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpTrafficThreshold))
+            .toJson
+            .compactPrint},
+             |"httpStatusThresholds" : ${httpStatusThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusThreshold))
+            .toJson
+            .compactPrint},
+             |"httpStatusPercentThresholds" : ${httpStatusPercentThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpStatusPercentThreshold))
+            .toJson
+            .compactPrint},
+             |"metricsThresholds" : ${printSeq(metricsThresholds.filterNot(a =>
+            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.MetricsThreshold)))(MetricsThresholdProtocol.thresholdFormat)},
              |"total-http-request-threshold": $updatedTotalHttpRequestThreshold,
-             |"log-message-thresholds" : ${logMessageThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold)).toJson.compactPrint},
+             |"log-message-thresholds" : ${logMessageThresholds
+            .filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.LogMessageThreshold))
+            .toJson
+            .compactPrint},
              |"average-cpu-threshold" : $updatedAverageCPUThreshold,
-             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
-             |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold)))(HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
-             |"absolute-percentage-split-downstream-hod-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamHodThresholds.filterNot(a => isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold)))(HttpAbsolutePercentSplitDownstreamHodThresholdProtocol.thresholdFormat)}
+             |"absolute-percentage-split-threshold" : ${printSeq(httpAbsolutePercentSplitThresholds.filterNot(a =>
+            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitThreshold)))(
+            HttpAbsolutePercentSplitThresholdProtocol.thresholdFormat)},
+             |"absolute-percentage-split-downstream-service-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamServiceThresholds.filterNot(a =>
+            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitDownstreamServiceThreshold)))(
+            HttpAbsolutePercentSplitDownstreamServiceThresholdProtocol.thresholdFormat)},
+             |"absolute-percentage-split-downstream-hod-threshold" : ${printSeq(httpAbsolutePercentSplitDownstreamHodThresholds.filterNot(a =>
+            isGrafanaEnabled(a.alertingPlatform, currentEnvironment, AlertType.HttpAbsolutePercentSplitDownstreamHodThreshold)))(
+            HttpAbsolutePercentSplitDownstreamHodThresholdProtocol.thresholdFormat)}
              |}
               """.stripMargin
       }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CheckIntervalMinutes.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CheckIntervalMinutes.scala
@@ -19,17 +19,16 @@ package uk.gov.hmrc.alertconfig.builder.custom
 object CheckIntervalMinutes {
   type CheckIntervalMinutes = Int
 
-  val DEFAULT = 2
-  val ONE_MINUTE = 1
-  val TWO_MINUTES = 2
-  val THREE_MINUTES = 3
-  val FOUR_MINUTES = 4
-  val FIVE_MINUTES = 5
-  val TEN_MINUTES = 10
+  val DEFAULT         = 2
+  val ONE_MINUTE      = 1
+  val TWO_MINUTES     = 2
+  val THREE_MINUTES   = 3
+  val FOUR_MINUTES    = 4
+  val FIVE_MINUTES    = 5
+  val TEN_MINUTES     = 10
   val FIFTEEN_MINUTES = 15
-  val THIRTY_MINUTES = 30
-  val ONE_HOUR = 60
-  val NINETY_MINUTES = 90
-  val EIGHT_HOURS = 8 * 60
+  val THIRTY_MINUTES  = 30
+  val ONE_HOUR        = 60
+  val NINETY_MINUTES  = 90
+  val EIGHT_HOURS     = 8 * 60
 }
-

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomCloudWatchMetricAlert.scala
@@ -44,9 +44,11 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   * @param operator
   *   Whether to evaluate the metric as greater than or less than
   * @param reducerFunction
-  *   Function to use to transform multiple data points returned from query into a single value, to be compared against the specified threshold. Valid values include: COUNT, LAST, MAX, MEAN, MIN, SUM.
-  *   Note: Using the LAST reducer could result in not all data points being considered during alert evaluation, depending on the frequency at which the alert runs.
-  *   Example: An alert with a LAST reducer, that runs every 2 minutes, based on a metric that is written on a per minute basis, will only consider ~50% of the data points, potentially missing a legitimate breach of an alert threshold.
+  *   Function to use to transform multiple data points returned from query into a single value, to be compared against the specified threshold. Valid
+  *   values include: COUNT, LAST, MAX, MEAN, MIN, SUM. Note: Using the LAST reducer could result in not all data points being considered during alert
+  *   evaluation, depending on the frequency at which the alert runs. Example: An alert with a LAST reducer, that runs every 2 minutes, based on a
+  *   metric that is written on a per minute basis, will only consider ~50% of the data points, potentially missing a legitimate breach of an alert
+  *   threshold.
   * @param runbookUrl
   *   Runbook for when this alert fires
   * @param severity
@@ -59,8 +61,9 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   Trigger point for each environment
   * @param statistic
   *   Used in the query. Valid values include Average, Maximum, Minimum, Sum, SampleCount, IQM
-  * @param queryTimeRangeMinutes 
-  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+  * @param queryTimeRangeMinutes
+  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one
+  *   minute ago (so that only fully shipped metrics are evaluated).
   * @param period
   *   CloudWatch metric statistics period
   */

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchAlert.scala
@@ -39,9 +39,11 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   * @param operator
   *   Whether to evaluate the metric as greater than or less than
   * @param reducerFunction
-  *   Function to use to transform multiple data points returned from query into a single value, to be compared against the specified threshold. Valid values include: COUNT, LAST, MAX, MEAN, MIN, SUM.
-  *   Note: Using the LAST reducer could result in not all data points being considered during alert evaluation, depending on the frequency at which the alert runs.
-  *   Example: An alert with a LAST reducer, that runs every 2 minutes, based on a metric that is written on a per minute basis, will only consider ~50% of the data points, potentially missing a legitimate breach of an alert threshold.
+  *   Function to use to transform multiple data points returned from query into a single value, to be compared against the specified threshold. Valid
+  *   values include: COUNT, LAST, MAX, MEAN, MIN, SUM. Note: Using the LAST reducer could result in not all data points being considered during alert
+  *   evaluation, depending on the frequency at which the alert runs. Example: An alert with a LAST reducer, that runs every 2 minutes, based on a
+  *   metric that is written on a per minute basis, will only consider ~50% of the data points, potentially missing a legitimate breach of an alert
+  *   threshold.
   * @param runbookUrl
   *   Runbook for when this alert fires
   * @param severity
@@ -52,7 +54,9 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   All alerts are prefixed with the team name
   * @param thresholds
   *   Trigger point for each environment
- * @param queryTimeRangeMinutes The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one minute ago (so that only fully shipped metrics are evaluated).
+  * @param queryTimeRangeMinutes
+  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one
+  *   minute ago (so that only fully shipped metrics are evaluated).
   */
 case class CustomElasticsearchAlert(
     alertName: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/EnvironmentThresholds.scala
@@ -18,12 +18,20 @@ package uk.gov.hmrc.alertconfig.builder.custom
 
 import uk.gov.hmrc.alertconfig.builder.Environment
 
-sealed trait NumberWrapper
-case class AsLong(value: Long) extends NumberWrapper
-case class AsDouble(value: Double) extends NumberWrapper
+sealed trait NumberWrapper {
+  override def toString: String
+}
+
+case class AsLong(value: Long) extends NumberWrapper {
+  override def toString: String = value.toString
+}
+
+case class AsDouble(value: Double) extends NumberWrapper {
+  override def toString: String = value.toString
+}
 
 object NumberWrapper {
-  implicit def longToNumberWrapper(l: Long): NumberWrapper = AsLong(l)
+  implicit def longToNumberWrapper(l: Long): NumberWrapper     = AsLong(l)
   implicit def doubleToNumberWrapper(d: Double): NumberWrapper = AsDouble(d)
 }
 
@@ -141,12 +149,12 @@ object EnvironmentThresholds {
   )
 
   /** Creates EnvironmentThresholds with the same threshold for all environments including management.
-   *
-   * @param threshold
-   * An integer to be set as the threshold for all seven environments including management.
-   * @return
-   * EnvironmentThresholds with the same threshold for all environments.
-   */
+    *
+    * @param threshold
+    *   An integer to be set as the threshold for all seven environments including management.
+    * @return
+    *   EnvironmentThresholds with the same threshold for all environments.
+    */
   def forAllEnvironmentsPlusManagement(threshold: NumberWrapper): EnvironmentThresholds = EnvironmentThresholds(
     production = Some(threshold),
     externaltest = Some(threshold),

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/Statistic.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/Statistic.scala
@@ -19,10 +19,10 @@ package uk.gov.hmrc.alertconfig.builder.custom
 object Statistic {
   type Statistic = String
 
-  val MAXIMUM = "Maximum"
-  val MINIMUM = "Minimum"
-  val AVERAGE   = "Average"
-  val SUM  = "Sum"
-  val SAMPLE_COUNT   = "SampleCount"
-  val IQM   = "IQM"
+  val MAXIMUM      = "Maximum"
+  val MINIMUM      = "Minimum"
+  val AVERAGE      = "Average"
+  val SUM          = "Sum"
+  val SAMPLE_COUNT = "SampleCount"
+  val IQM          = "IQM"
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
@@ -19,21 +19,20 @@ package uk.gov.hmrc.alertconfig.builder.custom
 object TimeRangeAsMinutes {
   type TimeRangeAsMinutes = Int
 
-  val DEFAULT = 15
-  val ONE_MINUTE = 1
-  val TWO_MINUTES = 2
-  val THREE_MINUTES = 3
-  val FOUR_MINUTES = 4
-  val FIVE_MINUTES = 5
-  val TEN_MINUTES = 10
-  val FIFTEEN_MINUTES = 15
-  val SIXTEEN_MINUTES = 16
-  val TWENTY_MINUTES = 20
-  val THIRTY_MINUTES = 30
-  val ONE_HOUR = 1 * 60
-  val NINETY_MINUTES = 90
-  val TWO_HOURS = 2 * 60
-  val TWELVE_HOURS = 12 * 60
+  val DEFAULT           = 15
+  val ONE_MINUTE        = 1
+  val TWO_MINUTES       = 2
+  val THREE_MINUTES     = 3
+  val FOUR_MINUTES      = 4
+  val FIVE_MINUTES      = 5
+  val TEN_MINUTES       = 10
+  val FIFTEEN_MINUTES   = 15
+  val SIXTEEN_MINUTES   = 16
+  val TWENTY_MINUTES    = 20
+  val THIRTY_MINUTES    = 30
+  val ONE_HOUR          = 1 * 60
+  val NINETY_MINUTES    = 90
+  val TWO_HOURS         = 2 * 60
+  val TWELVE_HOURS      = 12 * 60
   val TWENTY_FOUR_HOURS = 24 * 60
 }
-

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlAlerts.scala
@@ -75,6 +75,7 @@ case class YamlHttpAbsolutePercentSplitDownstreamServiceThresholdAlert(
     target: String,
     severity: String
 )
+
 case class YamlHttpEndpointAlert(
     httpEndpoint: String,
     cronCheckSchedule: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlWriter.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/YamlWriter.scala
@@ -27,7 +27,7 @@ object YamlWriter {
 
   // Define a filter to exclude 'environmentsEnabled' field
   private val propertyFilter = SimpleBeanPropertyFilter.serializeAllExcept("environmentsEnabled")
-  private val filters = new SimpleFilterProvider().addFilter("RemoveEnvironmentsEnabledField", propertyFilter)
+  private val filters        = new SimpleFilterProvider().addFilter("RemoveEnvironmentsEnabledField", propertyFilter)
 
   val mapper: ObjectMapper = new ObjectMapper(
     new YAMLFactory()

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilderSpec.scala
@@ -361,7 +361,6 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
     val target        = "hod-endpoint"
     val severity      = AlertSeverity.Warning
 
-
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttpAbsolutePercentSplitDownstreamHodThreshold(
         HttpAbsolutePercentSplitDownstreamHodThreshold(percent, crossOver, absolute, hysteresis, excludeSpikes, filter, target, severity))
@@ -474,7 +473,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   }
 
   "configure http5xxPercentThreshold with given thresholds when the alerting platform is Sensu" in {
-    val threshold = 13.3
+    val threshold         = 13.3
     val disabledThreshold = 333.33
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold)
@@ -493,7 +492,7 @@ class AlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAft
   }
 
   "configure http5xxPercentThreshold with count and percentage thresholds when the alerting platform is Sensu" in {
-    val threshold = 13.3
+    val threshold         = 13.3
     val disabledThreshold = 333.33
     val serviceConfig: Map[String, JsValue] = AlertConfigBuilder("service1", integrations = Seq("h1", "h2"))
       .withHttp5xxPercentThreshold(threshold, 10)

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/AllEnvironmentAlertConfigBuilderSpec.scala
@@ -56,7 +56,8 @@ class AllEnvironmentAlertConfigBuilderSpec extends AnyFunSuite with Matchers wit
 
   test("create config for production") {
     val environmentConfigMap =
-      AllEnvironmentAlertConfigBuilder.build(Set(EnvironmentAlertBuilder("team-telemetry").inProduction(), EnvironmentAlertBuilder("infra").inProduction()))
+      AllEnvironmentAlertConfigBuilder.build(
+        Set(EnvironmentAlertBuilder("team-telemetry").inProduction(), EnvironmentAlertBuilder("infra").inProduction()))
 
     environmentConfigMap(Environment.Production) shouldBe
       JsObject(

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -211,7 +211,6 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val target     = "hod-endpoint"
       val severity   = AlertSeverity.Warning
 
-
       val alertConfigBuilder = TeamAlertConfigBuilder
         .teamAlerts(Seq("service1", "service2"))
         .withHttpAbsolutePercentSplitDownstreamHodThreshold(


### PR DESCRIPTION
What did we do?
--

1. scala fmt all & fix issue with yaml output showing e.g. "value: 9" instead of "9" after latest merge

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4784

Next Steps
--

1. Test the yaml is correct... not sure how to generate the yaml locally :/ 

Risks
--

1. Yaml is still not correct

Collaboration
--

Co-authored-by: @gavD 
