### PR TITLE
TEL-4770 improve method of disabling alerts

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfig.scala
@@ -22,5 +22,5 @@ trait AlertConfig {
   // empty by default to force override
   def environmentConfig: Seq[EnvironmentAlertBuilder]
 
-  implicit def teamAlertConfigToAlertConfigs(config: TeamAlertConfigBuilder): Seq[AlertConfigBuilder] = config.build
+  implicit def teamAlertConfigToAlertConfigs(config: TeamAlertConfigBuilder): Seq[AlertConfigBuilder] = config.build()
 }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -18,23 +18,23 @@ package uk.gov.hmrc.alertconfig.builder
 
 case class AlertConfigBuilder(
     serviceName: String,
-    integrations: Seq[String] = Seq("noop"),
-    errorsLoggedThreshold: ErrorsLoggedThreshold = ErrorsLoggedThreshold(),
-    exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
-    http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
-    http5xxPercentThreshold: Http5xxPercentThreshold = Http5xxPercentThreshold(100.0),
+    integrations: Seq[String] = Nil,
+    errorsLoggedThreshold: Option[ErrorsLoggedThreshold] = None,
+    exceptionThreshold: Option[ExceptionThreshold] = Some(ExceptionThreshold(2)),
+    http5xxThreshold: Option[Http5xxThreshold] = None,
+    http5xxPercentThreshold: Option[Http5xxPercentThreshold] = Some(Http5xxPercentThreshold(100.0)),
     http90PercentileResponseTimeThresholds: Seq[Http90PercentileResponseTimeThreshold] = Nil,
     httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold] = Nil,
     httpAbsolutePercentSplitDownstreamServiceThresholds: Seq[HttpAbsolutePercentSplitDownstreamServiceThreshold] = Nil,
     httpAbsolutePercentSplitDownstreamHodThresholds: Seq[HttpAbsolutePercentSplitDownstreamHodThreshold] = Nil,
-    containerKillThreshold: ContainerKillThreshold = ContainerKillThreshold(1),
+    containerKillThreshold: Option[ContainerKillThreshold] = Some(ContainerKillThreshold(1)),
     httpTrafficThresholds: Seq[HttpTrafficThreshold] = Nil,
     httpStatusThresholds: Seq[HttpStatusThreshold] = Nil,
     httpStatusPercentThresholds: Seq[HttpStatusPercentThreshold] = Nil,
     metricsThresholds: Seq[MetricsThreshold] = Nil,
     logMessageThresholds: Seq[LogMessageThreshold] = Nil,
-    totalHttpRequestThreshold: TotalHttpRequestThreshold = TotalHttpRequestThreshold(),
-    averageCPUThreshold: AverageCPUThreshold = AverageCPUThreshold(),
+    totalHttpRequestThreshold: Option[TotalHttpRequestThreshold] = None,
+    averageCPUThreshold: Option[AverageCPUThreshold] = None,
     platformService: Boolean = false
 ) {
 
@@ -56,7 +56,7 @@ case class AlertConfigBuilder(
     *   <pre> {@code .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window } </pre>
     */
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int) =
-    this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold))
+    this.copy(errorsLoggedThreshold = Some(ErrorsLoggedThreshold(errorsLoggedThreshold)))
 
   /** This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
     * @param count
@@ -66,7 +66,7 @@ case class AlertConfigBuilder(
     *   <pre> {@code .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical) } </pre>
     */
   def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity))
+    this.copy(exceptionThreshold = Some(ExceptionThreshold(exceptionThreshold, severity)))
 
   /** This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
     *
@@ -80,7 +80,7 @@ case class AlertConfigBuilder(
     *   AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window } </pre>
     */
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
+    this.copy(http5xxThreshold = Some(Http5xxThreshold(http5xxThreshold, severity)))
 
   /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
     * window.
@@ -104,7 +104,7 @@ case class AlertConfigBuilder(
     *   status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window } </pre>
     */
   def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity))
+    this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
 
   /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
     * @param threshold
@@ -208,7 +208,7 @@ case class AlertConfigBuilder(
     *   window } </pre>
     */
   def withContainerKillThreshold(containerCrashThreshold: Int) =
-    this.copy(containerKillThreshold = ContainerKillThreshold(containerCrashThreshold))
+    this.copy(containerKillThreshold = Some(ContainerKillThreshold(containerCrashThreshold)))
 
   /** This alert will notify when your microservice receives a given number of requests within a 15-minute window.
     *
@@ -218,7 +218,7 @@ case class AlertConfigBuilder(
     *   <pre> {@code .withTotalHttpRequestThreshold(1000) # alert when 1000 requests are received in a 15-minute window } </pre>
     */
   def withTotalHttpRequestThreshold(threshold: Int) =
-    this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold))
+    this.copy(totalHttpRequestThreshold = Some(TotalHttpRequestThreshold(threshold)))
 
   /** This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
     * @param message
@@ -249,7 +249,7 @@ case class AlertConfigBuilder(
     *   } </pre>
     */
   def withAverageCPUThreshold(averageCPUThreshold: Int) =
-    this.copy(averageCPUThreshold = AverageCPUThreshold(averageCPUThreshold))
+    this.copy(averageCPUThreshold = Some(AverageCPUThreshold(averageCPUThreshold)))
 
   /** In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service. However, since platform
     * services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to
@@ -268,23 +268,23 @@ case class AlertConfigBuilder(
 
 case class TeamAlertConfigBuilder(
     services: Seq[String],
-    integrations: Seq[String] = Seq("noop"),
-    errorsLoggedThreshold: ErrorsLoggedThreshold = ErrorsLoggedThreshold(),
-    exceptionThreshold: ExceptionThreshold = ExceptionThreshold(),
-    http5xxThreshold: Http5xxThreshold = Http5xxThreshold(),
-    http5xxPercentThreshold: Http5xxPercentThreshold = Http5xxPercentThreshold(100.0),
+    integrations: Seq[String] = Nil,
+    errorsLoggedThreshold: Option[ErrorsLoggedThreshold] = None,
+    exceptionThreshold: Option[ExceptionThreshold] = Some(ExceptionThreshold(2)),
+    http5xxThreshold: Option[Http5xxThreshold] = None,
+    http5xxPercentThreshold: Option[Http5xxPercentThreshold] = Some(Http5xxPercentThreshold(100.0)),
     http90PercentileResponseTimeThresholds: Seq[Http90PercentileResponseTimeThreshold] = Nil,
     httpAbsolutePercentSplitThresholds: Seq[HttpAbsolutePercentSplitThreshold] = Nil,
     httpAbsolutePercentSplitDownstreamServiceThresholds: Seq[HttpAbsolutePercentSplitDownstreamServiceThreshold] = Nil,
     httpAbsolutePercentSplitDownstreamHodThresholds: Seq[HttpAbsolutePercentSplitDownstreamHodThreshold] = Nil,
-    containerKillThreshold: ContainerKillThreshold = ContainerKillThreshold(1),
+    containerKillThreshold: Option[ContainerKillThreshold] = Some(ContainerKillThreshold(1)),
     httpTrafficThresholds: Seq[HttpTrafficThreshold] = Nil,
     httpStatusThresholds: Seq[HttpStatusThreshold] = Nil,
     httpStatusPercentThresholds: Seq[HttpStatusPercentThreshold] = Nil,
     metricsThresholds: Seq[MetricsThreshold] = Nil,
     logMessageThresholds: Seq[LogMessageThreshold] = Nil,
-    totalHttpRequestThreshold: TotalHttpRequestThreshold = TotalHttpRequestThreshold(),
-    averageCPUThreshold: AverageCPUThreshold = AverageCPUThreshold(),
+    totalHttpRequestThreshold: Option[TotalHttpRequestThreshold] = None,
+    averageCPUThreshold: Option[AverageCPUThreshold] = None,
     platformService: Boolean = false
 ) {
 
@@ -304,7 +304,7 @@ case class TeamAlertConfigBuilder(
     *   <pre> {@code .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window } </pre>
     */
   def withErrorsLoggedThreshold(errorsLoggedThreshold: Int) =
-    this.copy(errorsLoggedThreshold = ErrorsLoggedThreshold(errorsLoggedThreshold))
+    this.copy(errorsLoggedThreshold = Some(ErrorsLoggedThreshold(errorsLoggedThreshold)))
 
   /** This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
     * @param count
@@ -314,7 +314,7 @@ case class TeamAlertConfigBuilder(
     *   <pre> {@code .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical) } </pre>
     */
   def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(exceptionThreshold = ExceptionThreshold(exceptionThreshold, severity))
+    this.copy(exceptionThreshold = Some(ExceptionThreshold(exceptionThreshold, severity)))
 
   /** This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
     *
@@ -328,7 +328,7 @@ case class TeamAlertConfigBuilder(
     *   AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window } </pre>
     */
   def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(http5xxThreshold = Http5xxThreshold(http5xxThreshold, severity))
+    this.copy(http5xxThreshold = Some(Http5xxThreshold(http5xxThreshold, severity)))
 
   /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
     * window.
@@ -352,7 +352,7 @@ case class TeamAlertConfigBuilder(
     *   status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window } </pre>
     */
   def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical) =
-    this.copy(http5xxPercentThreshold = Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity))
+    this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
 
   /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
     * @param threshold
@@ -398,7 +398,7 @@ case class TeamAlertConfigBuilder(
     *   window } </pre>
     */
   def withContainerKillThreshold(containerKillThreshold: Int) =
-    this.copy(containerKillThreshold = ContainerKillThreshold(containerKillThreshold))
+    this.copy(containerKillThreshold = Some(ContainerKillThreshold(containerKillThreshold)))
 
   /** This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
     *
@@ -458,7 +458,7 @@ case class TeamAlertConfigBuilder(
     *   <pre> {@code .withTotalHttpRequestThreshold(1000) # alert when 1000 requests are received in a 15-minute window } </pre>
     */
   def withTotalHttpRequestThreshold(threshold: Int) =
-    this.copy(totalHttpRequestThreshold = TotalHttpRequestThreshold(threshold))
+    this.copy(totalHttpRequestThreshold = Some(TotalHttpRequestThreshold(threshold)))
 
   /** This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
     * @param message
@@ -489,7 +489,7 @@ case class TeamAlertConfigBuilder(
     *   } </pre>
     */
   def withAverageCPUThreshold(averageCPUThreshold: Int) =
-    this.copy(averageCPUThreshold = AverageCPUThreshold(averageCPUThreshold))
+    this.copy(averageCPUThreshold = Some(AverageCPUThreshold(averageCPUThreshold)))
 
   /** In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service. However, since platform
     * services don't have app-config entries by design, the creation of alerts for these services can be forced by adding .isPlatformService(true) to

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -91,7 +91,7 @@ case class AlertConfigBuilder(
   /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
     * window.
     *
-    * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+    * This alert is enabled by default at 100%, but can be disabled by using .disableHttp5xxPercentThreshold().
     *
     * @param percentThreshold
     *   The %age of requests that must be 5xx to trigger the alarm
@@ -110,7 +110,13 @@ case class AlertConfigBuilder(
    *  status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window </pre> </pre>
     */
   def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical): AlertConfigBuilder =
-    this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
+    if (percentThreshold >= 100) {
+      println(Console.CYAN + s" = ${percentThreshold}" + Console.RESET)
+      throw new Exception(
+        s"withHttp5xxPercentThreshold percentThreshold '${percentThreshold}' cannot be over 100% - use .disableHttp5xxPercentThreshold() to disable this alert")
+    } else {
+      this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
+    }
 
   /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
     * @param threshold
@@ -352,7 +358,7 @@ case class TeamAlertConfigBuilder(
   /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
     * window.
     *
-    * This alert is enabled by default at 100%, but can be disabled by setting it to >100.
+    * This alert is enabled by default at 100%, but can be disabled by using .disableHttp5xxPercentThreshold().
     *
     * @param percentThreshold
     *   The %age of requests that must be 5xx to trigger the alarm
@@ -371,7 +377,13 @@ case class TeamAlertConfigBuilder(
    *  status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window </pre> </pre>
     */
   def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical): TeamAlertConfigBuilder =
-    this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
+    if (percentThreshold >= 100) {
+      println(Console.CYAN + s" = ${percentThreshold}" + Console.RESET)
+      throw new Exception(
+        s"withHttp5xxPercentThreshold percentThreshold '${percentThreshold}' cannot be over 100% - use .disableHttp5xxPercentThreshold() to disable this alert")
+    } else {
+      this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
+    }
 
   /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
     * @param threshold

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -207,6 +207,10 @@ case class AlertConfigBuilder(
   def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold): AlertConfigBuilder =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
+  /** This will disable the ContainerKillThreshold alert which is configured with a threshold of 1 by default */
+  def disableContainerKillThreshold(): AlertConfigBuilder =
+    this.copy(containerKillThreshold = None)
+
   /** All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed
     * with an out-of-memory exception. This alert will notify when a specified number of containers are killed within a 15-minute window.
     *
@@ -417,6 +421,10 @@ case class TeamAlertConfigBuilder(
    */
   def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold): TeamAlertConfigBuilder =
     this.copy(httpAbsolutePercentSplitDownstreamHodThresholds = httpAbsolutePercentSplitDownstreamHodThresholds :+ threshold)
+
+  /** This will disable the ContainerKillThreshold alert which is configured with a threshold of 1 by default */
+  def disableContainerKillThreshold(): TeamAlertConfigBuilder =
+    this.copy(containerKillThreshold = None)
 
   /** All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed
     * with an out-of-memory exception. This alert will notify when a specified number of containers are killed within a 15-minute window.

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -40,11 +40,11 @@ case class AlertConfigBuilder(
 
   val logger = new Logger()
 
-  /** Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
-    * @param string
-    *   The name of your pagerduty integration. This integration must already exist in PagerDuty; alert-config will not create it for you.
+  /** Set of integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
+    * @param integrations
+    *   List of names of your pagerduty integrations. These integrations must already exist in PagerDuty; alert-config will not create then for you.
     */
-  def withIntegrations(integrations: String*) =
+  def withIntegrations(integrations: String*): AlertConfigBuilder =
     this.copy(integrations = integrations)
 
   /** This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
@@ -53,19 +53,22 @@ case class AlertConfigBuilder(
     *   The number of logs at ERROR level that this alert will trigger on
     * @return
     * @example
-    *   <pre> {@code .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window } </pre>
+    * <pre> <pre>.withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window </pre> </pre>
     */
-  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int) =
+  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int): AlertConfigBuilder =
     this.copy(errorsLoggedThreshold = Some(ErrorsLoggedThreshold(errorsLoggedThreshold)))
 
+  /** This will disable the ExceptionThreshold alert which is configured with a threshold of 2 by default */
+  def disableExceptionThreshold(): AlertConfigBuilder = this.copy(exceptionThreshold = None)
+
   /** This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
-    * @param count
+    * @param exceptionThreshold
     *   The number of exceptions thrown that this alert will trigger on
     * @return
     * @example
-    *   <pre> {@code .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical) } </pre>
+    * <pre> <pre>.withExceptionThreshold(count: Int, severity: AlertSeverity &#61; AlertSeverity.Critical) </pre> </pre>
     */
-  def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical): AlertConfigBuilder =
     this.copy(exceptionThreshold = Some(ExceptionThreshold(exceptionThreshold, severity)))
 
   /** This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
@@ -76,11 +79,14 @@ case class AlertConfigBuilder(
     *   Whether to raise the alert as critical or warning
     * @return
     * @example
-    *   <pre> {@code .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window .withHttp5xxThreshold(5,
-    *   AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window } </pre>
+    * <pre> <pre>.withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window .withHttp5xxThreshold(5,
+   *  AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window </pre> </pre>
     */
-  def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical): AlertConfigBuilder =
     this.copy(http5xxThreshold = Some(Http5xxThreshold(http5xxThreshold, severity)))
+
+  /** This will disable the Http5xxPercentThreshold alert which is configured with a threshold of 100% by default */
+  def disableHttp5xxPercentThreshold(): AlertConfigBuilder = this.copy(http5xxPercentThreshold = None)
 
   /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
     * window.
@@ -98,12 +104,12 @@ case class AlertConfigBuilder(
     * @return
     *   Configured threshold object
     * @example
-    *   <pre> {@code .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
-    *   .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a
-    *   15-minute window .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx
-    *   status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window } </pre>
+    * <pre> <pre>.withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
+   *  .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a
+   *  15-minute window .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx
+   *  status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window </pre> </pre>
     */
-  def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical): AlertConfigBuilder =
     this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
 
   /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
@@ -111,10 +117,10 @@ case class AlertConfigBuilder(
     *   Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
     * @return
     * @example
-    *   <pre> {@code .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000),
-    *   timePeriod = 7)) } </pre>
+    * <pre> <pre>.withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning &#61; Some(1000), critical &#61; Some(2000),
+   *  timePeriod &#61; 7)) </pre> </pre>
     */
-  def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
+  def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold): AlertConfigBuilder = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
     } else {
@@ -123,29 +129,32 @@ case class AlertConfigBuilder(
   }
 
   /** @param threshold
+    *   Object with fields percentThreshold, crossover, absoluteThreshold, hysteresis, excludeSpikes, errorFilter, severity
     * @return
     * @example
-    *   <pre> {@code .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499")) } </pre>
+    * <pre> <pre>.withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499")) </pre> </pre>
     */
-  def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) =
+  def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold): AlertConfigBuilder =
     this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 
   /** @param threshold
+    *   Object with fields percentThreshold, crossover, absoluteThreshold, hysteresis, excludeSpikes, errorFilter, target, severity
     * @return
     * @example
-    *   <pre> {@code .withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(10.0, 0, -1, 1.1, 2,
-    *   "status:>498", "nps-hod-service",AlertSeverity.Critical)) } </pre>
+    * <pre> <pre>.withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(10.0, 0, -1, 1.1, 2,
+    *  "status:>498", "nps-hod-service",AlertSeverity.Critical)) </pre> </pre>
     */
-  def withHttpAbsolutePercentSplitDownstreamServiceThreshold(threshold: HttpAbsolutePercentSplitDownstreamServiceThreshold) =
+  def withHttpAbsolutePercentSplitDownstreamServiceThreshold(threshold: HttpAbsolutePercentSplitDownstreamServiceThreshold): AlertConfigBuilder =
     this.copy(httpAbsolutePercentSplitDownstreamServiceThresholds = httpAbsolutePercentSplitDownstreamServiceThresholds :+ threshold)
 
   /** @param threshold
+    * Object with fields percentThreshold, crossover, absoluteThreshold, hysteresis, excludeSpikes, errorFilter, target, severity
     * @return
     * @example
-    *   <pre> {@code .withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(10.0, 0, -1, 1.1, 2,
-    *   "status:>498", "nps-hod-service",AlertSeverity.Critical)) } </pre>
+    * <pre> <pre>.withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(10.0, 0, -1, 1.1, 2,
+    *  "status:>498", "nps-hod-service",AlertSeverity.Critical)) </pre> </pre>
     */
-  def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold) =
+  def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold): AlertConfigBuilder =
     this.copy(httpAbsolutePercentSplitDownstreamHodThresholds = httpAbsolutePercentSplitDownstreamHodThresholds :+ threshold)
 
   /** This alert will notify when your microservice returns a specified number of requests with a given http status code (between 400 and 599) within
@@ -155,13 +164,13 @@ case class AlertConfigBuilder(
     * @return
     *
     * @example
-    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
-    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
-    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
-    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window } </pre>
+    * <pre> <pre>.withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
+   *  window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+   *  .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
+   *  code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
+   *  raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window </pre> </pre>
     */
-  def withHttpStatusThreshold(threshold: HttpStatusThreshold) =
+  def withHttpStatusThreshold(threshold: HttpStatusThreshold): AlertConfigBuilder =
     this.copy(httpStatusThresholds = httpStatusThresholds :+ threshold)
 
   /** This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
@@ -169,15 +178,14 @@ case class AlertConfigBuilder(
     * One or both of warning and critical must be given.
     *
     * @param threshold
+    * Object with fields warning, critical and maxMinutesBelowThreshold
     * @return
     * @example
-    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
-    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
-    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
-    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window }
+    * <pre> <pre>.withHttpTrafficThreshold(HttpTrafficThreshold(10, 5, 15)) # alert with a warning when less than 10
+    * requests or critical when less than 5 requests are received in a 15-minute
+    * </pre>
     */
-  def withHttpTrafficThreshold(threshold: HttpTrafficThreshold) = {
+  def withHttpTrafficThreshold(threshold: HttpTrafficThreshold): AlertConfigBuilder = {
     if (httpTrafficThresholds.nonEmpty) {
       throw new Exception("withHttpTrafficThreshold has already been defined for this microservice")
     } else {
@@ -188,14 +196,15 @@ case class AlertConfigBuilder(
   /** This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
     *
     * @param threshold
+    * Object with fields httpStatus, percentage, severity and httpMethod
     * @return
-    *   <pre> {@code .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status
-    *   code 404 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all
-    *   requests return status code 500 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0,
-    *   AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window }
-    *   </pre>
+    * <pre> <pre>.withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status
+    *  code 404 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all
+    *  requests return status code 500 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0,
+    *  AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window </pre>
+    * </pre>
     */
-  def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
+  def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold): AlertConfigBuilder =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
   /** All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed
@@ -204,10 +213,10 @@ case class AlertConfigBuilder(
     * @param containerCrashThreshold
     *   The number of container kills to alert on
     * @return
-    *   <pre> {@code .withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute
-    *   window } </pre>
+    * <pre> <pre>.withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute
+   *  window </pre> </pre>
     */
-  def withContainerKillThreshold(containerCrashThreshold: Int) =
+  def withContainerKillThreshold(containerCrashThreshold: Int): AlertConfigBuilder =
     this.copy(containerKillThreshold = Some(ContainerKillThreshold(containerCrashThreshold)))
 
   /** This alert will notify when your microservice receives a given number of requests within a 15-minute window.
@@ -215,9 +224,9 @@ case class AlertConfigBuilder(
     * @param threshold
     *   The number of all http requests to alert on
     * @return
-    *   <pre> {@code .withTotalHttpRequestThreshold(1000) # alert when 1000 requests are received in a 15-minute window } </pre>
+    * <pre> <pre>.withTotalHttpRequestThreshold(1000) # alert when 1000 requests are received in a 15-minute window </pre> </pre>
     */
-  def withTotalHttpRequestThreshold(threshold: Int) =
+  def withTotalHttpRequestThreshold(threshold: Int): AlertConfigBuilder =
     this.copy(totalHttpRequestThreshold = Some(TotalHttpRequestThreshold(threshold)))
 
   /** This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
@@ -230,13 +239,13 @@ case class AlertConfigBuilder(
     * @param severity
     *   The severity to set for this check in PagerDuty
     * @return
-    *   <pre> {@code .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
-    *   .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute
-    *   window .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs
-    *   containing `MY_LOG_MESSAGE` are detected .withLogMessageThreshold("MY_LOG_MESSAGE", 2) // Raise an alert when a service generates two or more
-    *   logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe. }
+    * <pre> <pre>.withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
+   *  .withLogMessageThreshold("heartbeat", 4, lessThanMode&#61;true) // triggers if a specific log message appears less than 4 times in a 15-minute
+   *  window .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity &#61; AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs
+   *  containing &#96;MY_LOG_MESSAGE&#96; are detected .withLogMessageThreshold("MY_LOG_MESSAGE", 2) // Raise an alert when a service generates two or more
+   *  logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe. </pre>
     */
-  def withLogMessageThreshold(message: String, threshold: Int, lessThanMode: Boolean = false, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withLogMessageThreshold(message: String, threshold: Int, lessThanMode: Boolean = false, severity: AlertSeverity = AlertSeverity.Critical): AlertConfigBuilder =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity))
 
   /** This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
@@ -245,10 +254,10 @@ case class AlertConfigBuilder(
     *   The average percentage CPU used by all instances of your microservice
     * @return
     * @example
-    *   <pre> {@code .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
-    *   } </pre>
+    * <pre> <pre>.withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
+   *  </pre> </pre>
     */
-  def withAverageCPUThreshold(averageCPUThreshold: Int) =
+  def withAverageCPUThreshold(averageCPUThreshold: Int): AlertConfigBuilder =
     this.copy(averageCPUThreshold = Some(AverageCPUThreshold(averageCPUThreshold)))
 
   /** In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service. However, since platform
@@ -288,11 +297,11 @@ case class TeamAlertConfigBuilder(
     platformService: Boolean = false
 ) {
 
-  /** Sets integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
-    * @param string
-    *   The name of your pagerduty integration. This integration must already exist in PagerDuty; alert-config will not create it for you.
+  /** Set of integrations for the configuration, e.g. .withIntegrations("dass-cyclone")
+    * @param integrations
+    *   List of names of your pagerduty integrations. These integration must already exist in PagerDuty; alert-config will not create them for you.
     */
-  def withIntegrations(integrations: String*) =
+  def withIntegrations(integrations: String*): TeamAlertConfigBuilder =
     this.copy(integrations = integrations)
 
   /** This alert will notify when your microservice logs a specified number of logs at ERROR log level within a 15-minute window.
@@ -301,19 +310,22 @@ case class TeamAlertConfigBuilder(
     *   The number of logs at ERROR level that this alert will trigger on
     * @return
     * @example
-    *   <pre> {@code .withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window } </pre>
+    * <pre> <pre>.withErrorsLoggedThreshold(5) # alert when 5 logs at ERROR level are logged in a 15-minute window </pre> </pre>
     */
-  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int) =
+  def withErrorsLoggedThreshold(errorsLoggedThreshold: Int): TeamAlertConfigBuilder =
     this.copy(errorsLoggedThreshold = Some(ErrorsLoggedThreshold(errorsLoggedThreshold)))
 
+  /** This will disable the ExceptionThreshold alert which is configured with a threshold of 2 by default */
+  def disableExceptionThreshold(): TeamAlertConfigBuilder = this.copy(exceptionThreshold = None)
+
   /** This alert will notify when your microservice throws a specified number of exceptions, at log level ERROR, within a 15-minute window.
-    * @param count
+    * @param exceptionThreshold
     *   The number of exceptions thrown that this alert will trigger on
     * @return
     * @example
-    *   <pre> {@code .withExceptionThreshold(count: Int, severity: AlertSeverity = AlertSeverity.Critical) } </pre>
+    * <pre> <pre>.withExceptionThreshold(count: Int, severity: AlertSeverity &#61; AlertSeverity.Critical) </pre> </pre>
     */
-  def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withExceptionThreshold(exceptionThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical): TeamAlertConfigBuilder =
     this.copy(exceptionThreshold = Some(ExceptionThreshold(exceptionThreshold, severity)))
 
   /** This alert will notify when the number of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute window.
@@ -324,11 +336,14 @@ case class TeamAlertConfigBuilder(
     *   Whether to raise the alert as critical or warning
     * @return
     * @example
-    *   <pre> {@code .withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window .withHttp5xxThreshold(5,
-    *   AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window } </pre>
+    * <pre> <pre>.withHttp5xxThreshold(5) # alert when 5 requests return a 5xx status code in a 15-minute window .withHttp5xxThreshold(5,
+   *  AlertSeverity.Warning) # raise a warning alert when 5 requests return a 5xx status code in a 15-minute window </pre> </pre>
     */
-  def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withHttp5xxThreshold(http5xxThreshold: Int, severity: AlertSeverity = AlertSeverity.Critical): TeamAlertConfigBuilder =
     this.copy(http5xxThreshold = Some(Http5xxThreshold(http5xxThreshold, severity)))
+
+  /** This will disable the Http5xxPercentThreshold alert which is configured with a threshold of 100% by default */
+  def disableHttp5xxPercentThreshold(): TeamAlertConfigBuilder = this.copy(http5xxPercentThreshold = None)
 
   /** This alert will notify when the percentage of http responses returning a 5xx http status code exceeds a given threshold within a 15-minute
     * window.
@@ -346,12 +361,12 @@ case class TeamAlertConfigBuilder(
     * @return
     *   Configured threshold object
     * @example
-    *   <pre> {@code .withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
-    *   .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a
-    *   15-minute window .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx
-    *   status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window } </pre>
+    * <pre> <pre>.withHttp5xxPercentThreshold(25.0) # alert when 25% of all requests return a 5xx status code in a 15-minute window
+   *  .withHttp5xxPercentThreshold(25.0, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx status code in a
+   *  15-minute window .withHttp5xxPercentThreshold(25.0, 5, AlertSeverity.Warning) # raise a warning alert when 25% of all requests return a 5xx
+   *  status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window </pre> </pre>
     */
-  def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical): TeamAlertConfigBuilder =
     this.copy(http5xxPercentThreshold = Some(Http5xxPercentThreshold(percentThreshold, minimumHttp5xxCountThreshold, severity)))
 
   /** This alert will notify you when the 90th Percentile request time goes above the defined thresholds for the time period specified by the user.
@@ -359,13 +374,13 @@ case class TeamAlertConfigBuilder(
     *   Object representing the response time in milliseconds above which alerts will be raised at given severities for a given time period
     * @return
     * @example
-    *   <pre> {@code .withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning = Some(1000), critical = Some(2000),
-    *   timePeriod = 7)) } </pre>
+    * <pre> <pre>.withHttp90PercentileResponseTimeThreshold(Http90PercentileResponseTimeThreshold(warning &#61; Some(1000), critical &#61; Some(2000),
+   *  timePeriod &#61; 7)) </pre> </pre>
     */
-  def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold) = {
+  def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold): TeamAlertConfigBuilder = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
-    } else if (threshold.timePeriod <= 0 && threshold.timePeriod >= 15) {
+    } else if (threshold.timePeriod <= 0 || threshold.timePeriod >= 15) {
       println(Console.CYAN + s" = ${threshold}" + Console.RESET)
       throw new Exception(
         s"withHttp90PercentileResponseTimeThreshold timePeriod '${threshold.timePeriod}' needs to be in the range 1-15 minutes (inclusive)")
@@ -375,29 +390,44 @@ case class TeamAlertConfigBuilder(
   }
 
   /** @param threshold
+    *   Object with fields percentThreshold, crossover, absoluteThreshold, hysteresis, excludeSpikes, errorFilter, severity
     * @return
     * @example
-    *   <pre> {@code .withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499")) } </pre>
+    * <pre> <pre>.withHttpAbsolutePercentSplitThreshold(HttpAbsolutePercentSplitThreshold(100.0, Int.MaxValue, 40, 1.0, 2, "status:499")) </pre> </pre>
     */
-  def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold) =
+  def withHttpAbsolutePercentSplitThreshold(threshold: HttpAbsolutePercentSplitThreshold): TeamAlertConfigBuilder =
     this.copy(httpAbsolutePercentSplitThresholds = httpAbsolutePercentSplitThresholds :+ threshold)
 
-  def withHttpAbsolutePercentSplitDownstreamServiceThreshold(threshold: HttpAbsolutePercentSplitDownstreamServiceThreshold) =
+  /** @param threshold
+   * Object with fields percentThreshold, crossover, absoluteThreshold, hysteresis, excludeSpikes, errorFilter, target, severity
+   * @return
+   * @example
+   * <pre> <pre>.withHttpAbsolutePercentSplitDownstreamServiceThreshold(HttpAbsolutePercentSplitDownstreamServiceThreshold(10.0, 0, -1, 1.1, 2,
+   * "status:>498", "nps-hod-service",AlertSeverity.Critical)) </pre> </pre>
+   */
+  def withHttpAbsolutePercentSplitDownstreamServiceThreshold(threshold: HttpAbsolutePercentSplitDownstreamServiceThreshold): TeamAlertConfigBuilder =
     this.copy(httpAbsolutePercentSplitDownstreamServiceThresholds = httpAbsolutePercentSplitDownstreamServiceThresholds :+ threshold)
 
-  def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold) =
+  /** @param threshold
+   * Object with fields percentThreshold, crossover, absoluteThreshold, hysteresis, excludeSpikes, errorFilter, target, severity
+   * @return
+   * @example
+   * <pre> <pre>.withHttpAbsolutePercentSplitDownstreamHodThreshold(HttpAbsolutePercentSplitDownstreamHodThreshold(10.0, 0, -1, 1.1, 2,
+   * "status:>498", "nps-hod-service",AlertSeverity.Critical)) </pre> </pre>
+   */
+  def withHttpAbsolutePercentSplitDownstreamHodThreshold(threshold: HttpAbsolutePercentSplitDownstreamHodThreshold): TeamAlertConfigBuilder =
     this.copy(httpAbsolutePercentSplitDownstreamHodThresholds = httpAbsolutePercentSplitDownstreamHodThresholds :+ threshold)
 
   /** All microservices are deployed to MDTP inside docker containers. If the docker container runs out of memory then the container will be killed
     * with an out-of-memory exception. This alert will notify when a specified number of containers are killed within a 15-minute window.
     *
-    * @param containerCrashThreshold
+    * @param containerKillThreshold
     *   The number of container kills to alert on
     * @return
-    *   <pre> {@code .withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute
-    *   window } </pre>
+    * <pre> <pre>.withContainerKillThreshold(5) # alert if 5 microservice instances are killed with an out-of-memory exception in a 15-minute
+   *  window </pre> </pre>
     */
-  def withContainerKillThreshold(containerKillThreshold: Int) =
+  def withContainerKillThreshold(containerKillThreshold: Int): TeamAlertConfigBuilder =
     this.copy(containerKillThreshold = Some(ContainerKillThreshold(containerKillThreshold)))
 
   /** This alert will notify you when the total number of requests received by the microservice is below a certain threshold.
@@ -405,15 +435,14 @@ case class TeamAlertConfigBuilder(
     * One or both of warning and critical must be given.
     *
     * @param threshold
+    *   Object with fields warning, critical and maxMinutesBelowThreshold
     * @return
     * @example
-    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
-    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
-    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
-    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window }
+    * <pre> <pre>.withHttpTrafficThreshold(HttpTrafficThreshold(10, 5, 15)) # alert with a warning when less than 10
+    * requests or critical when less than 5 requests are received in a 15-minute
+    * </pre>
     */
-  def withHttpTrafficThreshold(threshold: HttpTrafficThreshold) = {
+  def withHttpTrafficThreshold(threshold: HttpTrafficThreshold): TeamAlertConfigBuilder = {
     if (httpTrafficThresholds.nonEmpty) {
       throw new Exception("withHttpTrafficThreshold has already been defined for this microservice")
     } else {
@@ -428,26 +457,27 @@ case class TeamAlertConfigBuilder(
     * @return
     *
     * @example
-    *   <pre> {@code .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
-    *   window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
-    *   .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
-    *   code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
-    *   raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window } </pre>
+    * <pre> <pre>.withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_500, 5)) # alert when 5 occurences of status code 500 in a 15-minute
+   *  window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS(501), 5)) # alert when 5 occurences of status code 501 in a 15-minute window
+   *  .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_502, 5, AlertSeverity.Warning)) # raise a warning alert when 5 occurences of status
+   *  code 502 in a 15-minute window .withHttpStatusThreshold(HttpStatusThreshold(HTTP_STATUS_503, 5, AlertSeverity.Warning, httpMethod.Post)) #
+   *  raise a warning alert when 5 occurences of Post requests with response status code 503 in a 15-minute window </pre> </pre>
     */
-  def withHttpStatusThreshold(threshold: HttpStatusThreshold) =
+  def withHttpStatusThreshold(threshold: HttpStatusThreshold): TeamAlertConfigBuilder =
     this.copy(httpStatusThresholds = httpStatusThresholds :+ threshold)
 
   /** This alert will notify when the percentage of http responses with a given http status code exceeds a given threshold within a 15-minute window.
     *
     * @param threshold
+    *   Object with fields httpStatus, percentage, severity and httpMethod
     * @return
-    *   <pre> {@code .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status
-    *   code 404 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all
-    *   requests return status code 500 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0,
-    *   AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window }
-    *   </pre>
+    * <pre> <pre>.withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_404, 25.0)) # alert when 25% of all requests return status
+   *  code 404 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_500, 25.0)) # alert when 25% of all
+   *  requests return status code 500 in a 15-minute window .withHttpStatusPercentThreshold(HttpStatusPercentThreshold(HTTP_STATUS_504, 25.0,
+   *  AlertSeverity.Warning, httpMethod.Post)) # raise a warning alert when 25% of all Post requests return status code 500 in a 15-minute window </pre>
+    * </pre>
     */
-  def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold) =
+  def withHttpStatusPercentThreshold(threshold: HttpStatusPercentThreshold): TeamAlertConfigBuilder =
     this.copy(httpStatusPercentThresholds = httpStatusPercentThresholds :+ threshold)
 
   /** This alert will notify when your microservice receives a given number of requests within a 15-minute window.
@@ -455,9 +485,9 @@ case class TeamAlertConfigBuilder(
     * @param threshold
     *   The number of all http requests to alert on
     * @return
-    *   <pre> {@code .withTotalHttpRequestThreshold(1000) # alert when 1000 requests are received in a 15-minute window } </pre>
+    * <pre> <pre>.withTotalHttpRequestThreshold(1000) # alert when 1000 requests are received in a 15-minute window </pre> </pre>
     */
-  def withTotalHttpRequestThreshold(threshold: Int) =
+  def withTotalHttpRequestThreshold(threshold: Int): TeamAlertConfigBuilder =
     this.copy(totalHttpRequestThreshold = Some(TotalHttpRequestThreshold(threshold)))
 
   /** This alert will notify when the count of a given log message is logged exceeds a given threshold within a 15-minute window.
@@ -470,13 +500,13 @@ case class TeamAlertConfigBuilder(
     * @param severity
     *   The severity to set for this check in PagerDuty
     * @return
-    *   <pre> {@code .withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
-    *   .withLogMessageThreshold("heartbeat", 4, lessThanMode=true) // triggers if a specific log message appears less than 4 times in a 15-minute
-    *   window .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity = AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs
-    *   containing `MY_LOG_MESSAGE` are detected .withLogMessageThreshold("MY_LOG_MESSAGE", 2) // Raise an alert when a service generates two or more
-    *   logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe. }
+    * <pre> <pre>.withLogMessageThreshold("Custom logs", 5) // occurrences of a specific log message in a 15-minute window
+   *  .withLogMessageThreshold("heartbeat", 4, lessThanMode&#61;true) // triggers if a specific log message appears less than 4 times in a 15-minute
+   *  window .withLogMessageThreshold("MY_LOG_MESSAGE", 10, severity &#61; AlertSeverity.Warning) // Raise warning alert in PagerDuty after 10 logs
+   *  containing &#96;MY_LOG_MESSAGE&#96; are detected .withLogMessageThreshold("MY_LOG_MESSAGE", 2) // Raise an alert when a service generates two or more
+   *  logs containing the specified MY_LOG_MESSAGE within a 15-minute timeframe. </pre>
     */
-  def withLogMessageThreshold(message: String, threshold: Int, lessThanMode: Boolean = false, severity: AlertSeverity = AlertSeverity.Critical) =
+  def withLogMessageThreshold(message: String, threshold: Int, lessThanMode: Boolean = false, severity: AlertSeverity = AlertSeverity.Critical): TeamAlertConfigBuilder =
     this.copy(logMessageThresholds = logMessageThresholds :+ LogMessageThreshold(message, threshold, lessThanMode, severity))
 
   /** This alert will notify when the average CPU used by all instances of your microservice exceeds a given threshold within a 5-minute window.
@@ -485,10 +515,10 @@ case class TeamAlertConfigBuilder(
     *   The average percentage CPU used by all instances of your microservice
     * @return
     * @example
-    *   <pre> {@code .withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
-    *   } </pre>
+    * <pre> <pre>.withAverageCPUThreshold(50) # alert if average CPU usage across all microservice instances is above 50% for the last 15 minutes
+   *  </pre> </pre>
     */
-  def withAverageCPUThreshold(averageCPUThreshold: Int) =
+  def withAverageCPUThreshold(averageCPUThreshold: Int): TeamAlertConfigBuilder =
     this.copy(averageCPUThreshold = Some(AverageCPUThreshold(averageCPUThreshold)))
 
   /** In order to generate an alert for a service, alert-config expects an entry in app-config-\$ENV for that service. However, since platform

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -384,7 +384,7 @@ case class TeamAlertConfigBuilder(
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold): TeamAlertConfigBuilder = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
-    } else if (threshold.timePeriod <= 0 || threshold.timePeriod >= 15) {
+    } else if (threshold.timePeriod < 0 || threshold.timePeriod > 15) {
       println(Console.CYAN + s" = ${threshold}" + Console.RESET)
       throw new Exception(
         s"withHttp90PercentileResponseTimeThreshold timePeriod '${threshold.timePeriod}' needs to be in the range 1-15 minutes (inclusive)")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AverageCPUThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AverageCPUThreshold.scala
@@ -21,5 +21,5 @@ package uk.gov.hmrc.alertconfig.builder
   *   The average percentage CPU used by all instances of your microservice
   */
 case class AverageCPUThreshold(
-    count: Int = Int.MaxValue
+    count: Int
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ContainerKillThreshold.scala
@@ -23,5 +23,5 @@ package uk.gov.hmrc.alertconfig.builder
   *   The number of container kills to alert on
   */
 case class ContainerKillThreshold(
-    count: Int = Int.MaxValue
+    count: Int
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ErrorsLoggedThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ErrorsLoggedThreshold.scala
@@ -17,5 +17,5 @@
 package uk.gov.hmrc.alertconfig.builder
 
 case class ErrorsLoggedThreshold(
-    count: Int = Int.MaxValue
+    count: Int
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/ExceptionThreshold.scala
@@ -23,6 +23,6 @@ package uk.gov.hmrc.alertconfig.builder
   *   Whether to raise the alert as critical or warning
   */
 case class ExceptionThreshold(
-    count: Int = 2,
+    count: Int,
     severity: AlertSeverity = AlertSeverity.Critical
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxPercentThreshold.scala
@@ -29,7 +29,7 @@ package uk.gov.hmrc.alertconfig.builder
   *   Whether to raise the alert as critical or warning
   */
 case class Http5xxPercentThreshold(
-    percentage: Double = 100.0,
+    percentage: Double,
     minimumHttp5xxCountThreshold: Int = 0,
     severity: AlertSeverity = AlertSeverity.Critical
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/Http5xxThreshold.scala
@@ -23,6 +23,6 @@ package uk.gov.hmrc.alertconfig.builder
   *   Whether to raise the alert as critical or warning
   */
 case class Http5xxThreshold(
-    count: Int = Int.MaxValue,
+    count: Int,
     severity: AlertSeverity = AlertSeverity.Critical
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/TotalHttpRequestThreshold.scala
@@ -22,5 +22,5 @@ package uk.gov.hmrc.alertconfig.builder
   *   The number of all http requests to alert on
   */
 case class TotalHttpRequestThreshold(
-    count: Int = Int.MaxValue
+    count: Int
 )

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -136,55 +136,37 @@ object AlertsYamlBuilder {
   }
 
   private def convertAverageCPUThreshold(averageCPUThreshold: Option[AverageCPUThreshold]): Option[YamlAverageCPUThresholdAlert] = {
-    val threshold = averageCPUThreshold.map(_.count).getOrElse(Int.MaxValue)
-    Option.when(threshold < Int.MaxValue)(
-      YamlAverageCPUThresholdAlert(threshold)
-    )
+    averageCPUThreshold.map(threshold => YamlAverageCPUThresholdAlert(threshold.count))
   }
 
   private def convertContainerKillThreshold(containerKillThreshold: Option[ContainerKillThreshold]): Option[YamlContainerKillThresholdAlert] = {
-    val threshold = containerKillThreshold.map(_.count).getOrElse(Int.MaxValue)
-    Option.when(threshold < Int.MaxValue)(
-      YamlContainerKillThresholdAlert(threshold)
-    )
+    containerKillThreshold.map(threshold => YamlContainerKillThresholdAlert(threshold.count))
   }
 
   private def convertErrorsLoggedThreshold(errorsLoggedThreshold: Option[ErrorsLoggedThreshold]): Option[YamlErrorsLoggedThresholdAlert] = {
-    val threshold = errorsLoggedThreshold.map(_.count).getOrElse(Int.MaxValue)
-    Option.when(threshold < Int.MaxValue)(
-      YamlErrorsLoggedThresholdAlert(threshold)
-    )
+    errorsLoggedThreshold.map(threshold => YamlErrorsLoggedThresholdAlert(threshold.count))
   }
 
   private def convertExceptionThreshold(exceptionThreshold: Option[ExceptionThreshold]): Option[YamlExceptionThresholdAlert] = {
-    val threshold = exceptionThreshold.map(_.count).getOrElse(Int.MaxValue)
-    Option.when(threshold < Int.MaxValue)(
-      YamlExceptionThresholdAlert(
-        count = threshold,
-        severity = exceptionThreshold.map(_.severity).getOrElse("critical").toString
-      )
-    )
+    exceptionThreshold.map(threshold => YamlExceptionThresholdAlert(
+      count = threshold.count,
+      severity = threshold.severity.toString
+    ))
   }
 
   private def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Option[Http5xxPercentThreshold]): Option[YamlHttp5xxPercentThresholdAlert] = {
-    val threshold = http5xxPercentThreshold.map(_.percentage).getOrElse(150.0)
-    Option.when(threshold <= 100.0)(
-      YamlHttp5xxPercentThresholdAlert(
-        percentage = threshold,
-        minimumHttp5xxCountThreshold = http5xxPercentThreshold.map(_.minimumHttp5xxCountThreshold).getOrElse(0),
-        severity = http5xxPercentThreshold.map(_.severity).getOrElse("critical").toString
-      )
-    )
+    http5xxPercentThreshold.filter(_.percentage <= 100.0).map(threshold => YamlHttp5xxPercentThresholdAlert(
+      percentage = threshold.percentage,
+      minimumHttp5xxCountThreshold = threshold.minimumHttp5xxCountThreshold,
+      severity = threshold.severity.toString
+    ))
   }
 
   private def convertHttp5xxThreshold(http5xxThreshold: Option[Http5xxThreshold]): Option[YamlHttp5xxThresholdAlert] = {
-    val threshold = http5xxThreshold.map(_.count).getOrElse(Int.MaxValue)
-    Option.when(threshold < Int.MaxValue)(
-      YamlHttp5xxThresholdAlert(
-        count = threshold,
-        severity = http5xxThreshold.map(_.severity).getOrElse("critical").toString
-      )
-    )
+    http5xxThreshold.map(threshold => YamlHttp5xxThresholdAlert(
+      count = threshold.count,
+      severity = threshold.severity.toString
+    ))
   }
 
   private def convertHttpAbsolutePercentSplitThresholdAlert(
@@ -305,10 +287,8 @@ object AlertsYamlBuilder {
   }
 
   private def convertTotalHttpRequestThreshold(totalHttpRequestThreshold: Option[TotalHttpRequestThreshold]): Option[YamlTotalHttpRequestThresholdAlert] = {
-    val threshold = totalHttpRequestThreshold.map(_.count).getOrElse(Int.MaxValue)
-    Option.when(threshold < Int.MaxValue)(
-      YamlTotalHttpRequestThresholdAlert(threshold)
-    )
+    totalHttpRequestThreshold.map(threshold =>
+      YamlTotalHttpRequestThresholdAlert(threshold.count))
   }
 
   private def convertMetricsThreshold(metricsThreshold: Seq[MetricsThreshold]): Option[Seq[YamlMetricsThresholdAlert]] = {

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilder.scala
@@ -155,7 +155,7 @@ object AlertsYamlBuilder {
   }
 
   private def convertHttp5xxPercentThresholds(http5xxPercentThreshold: Option[Http5xxPercentThreshold]): Option[YamlHttp5xxPercentThresholdAlert] = {
-    http5xxPercentThreshold.filter(_.percentage <= 100.0).map(threshold => YamlHttp5xxPercentThresholdAlert(
+    http5xxPercentThreshold.map(threshold => YamlHttp5xxPercentThresholdAlert(
       percentage = threshold.percentage,
       minimumHttp5xxCountThreshold = threshold.minimumHttp5xxCountThreshold,
       severity = threshold.severity.toString

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/TeamAlertConfigBuilderSpec.scala
@@ -57,18 +57,18 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
       val alertConfigBuilder: TeamAlertConfigBuilder = TeamAlertConfigBuilder.teamAlerts(Seq("service1", "service2"))
 
       alertConfigBuilder.services shouldBe Seq("service1", "service2")
-      alertConfigBuilder.integrations shouldBe Seq("noop")
-      alertConfigBuilder.averageCPUThreshold shouldBe AverageCPUThreshold(Int.MaxValue)
-      alertConfigBuilder.containerKillThreshold shouldBe ContainerKillThreshold(1)
-      alertConfigBuilder.exceptionThreshold shouldBe ExceptionThreshold(2, AlertSeverity.Critical)
-      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(100, severity = AlertSeverity.Critical)
-      alertConfigBuilder.http5xxThreshold shouldBe Http5xxThreshold(Int.MaxValue, AlertSeverity.Critical)
+      alertConfigBuilder.integrations shouldBe List()
+      alertConfigBuilder.averageCPUThreshold shouldBe None
+      alertConfigBuilder.containerKillThreshold shouldBe Some(ContainerKillThreshold(1))
+      alertConfigBuilder.exceptionThreshold shouldBe Some(ExceptionThreshold(2, AlertSeverity.Critical))
+      alertConfigBuilder.http5xxPercentThreshold shouldBe Some(Http5xxPercentThreshold(100, severity = AlertSeverity.Critical))
+      alertConfigBuilder.http5xxThreshold shouldBe None
       alertConfigBuilder.http90PercentileResponseTimeThresholds shouldBe List()
       alertConfigBuilder.httpAbsolutePercentSplitThresholds shouldBe List()
       alertConfigBuilder.httpStatusThresholds shouldBe List()
       alertConfigBuilder.httpTrafficThresholds shouldBe List()
       alertConfigBuilder.logMessageThresholds shouldBe List()
-      alertConfigBuilder.totalHttpRequestThreshold shouldBe TotalHttpRequestThreshold(Int.MaxValue)
+      alertConfigBuilder.totalHttpRequestThreshold shouldBe None
     }
 
     "result in identical defaults to AlertConfigBuilder" in {
@@ -118,7 +118,7 @@ class TeamAlertConfigBuilderSpec extends AnyWordSpec with Matchers with BeforeAn
         .teamAlerts(Seq("service1", "service2"))
         .withHttp5xxPercentThreshold(19.2, severity = AlertSeverity.Warning)
 
-      alertConfigBuilder.http5xxPercentThreshold shouldBe Http5xxPercentThreshold(19.2, severity = AlertSeverity.Warning)
+      alertConfigBuilder.http5xxPercentThreshold shouldBe Some(Http5xxPercentThreshold(19.2, severity = AlertSeverity.Warning))
     }
 
     "return TeamAlertConfigBuilder with correct integrations" in {

--- a/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/alertconfig/builder/yaml/AlertsYamlBuilderSpec.scala
@@ -121,8 +121,8 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           integrations = Seq("foo", "bar")
         )
           .withExceptionThreshold(9, AlertSeverity.Warning)
-          .withContainerKillThreshold(Int.MaxValue)
-          .withHttp5xxPercentThreshold(Int.MaxValue, 1, severity = AlertSeverity.Warning)
+          .disableContainerKillThreshold()
+          .disableHttp5xxPercentThreshold()
       )
 
       val fakeConfig = new AlertConfig {
@@ -172,8 +172,8 @@ class AlertsYamlBuilderSpec extends AnyWordSpec with Matchers with BeforeAndAfte
           integrations = Seq("foo", "bar")
         )
           .withExceptionThreshold(9, AlertSeverity.Critical)
-          .withContainerKillThreshold(Int.MaxValue)
-          .withHttp5xxPercentThreshold(Int.MaxValue, 1, severity = AlertSeverity.Warning)
+          .disableContainerKillThreshold()
+          .disableHttp5xxPercentThreshold()
       )
 
       val fakeConfig = new AlertConfig {


### PR DESCRIPTION
What did we do?
--

1. Improve the way that we disable alerts, by making each alert type `Option[x] = None` rather than `x=Int.MaxValue`

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4770

Evidence of work
--

1. Tests passing
2. Built library from branch and tested locally, with some changes in alert-config we end up with the exact same config

Next Steps
--

1. Will probably need to update any alert-configs which pass in thresholds using the constructor rather than the `.withThreshold` builder pattern. This has the added bonus of making alert-config more consistent

Risks
--

1. We accidentally enable alerts which have been disabled in unexpected ways
