### PR TITLE
TEL-4770 fix Http5xxPercentThreshold validation to support 100%

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -110,7 +110,7 @@ case class AlertConfigBuilder(
    *  status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window </pre> </pre>
     */
   def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical): AlertConfigBuilder =
-    if (percentThreshold >= 100) {
+    if (percentThreshold > 100) {
       println(Console.CYAN + s" = ${percentThreshold}" + Console.RESET)
       throw new Exception(
         s"withHttp5xxPercentThreshold percentThreshold '${percentThreshold}' cannot be over 100% - use .disableHttp5xxPercentThreshold() to disable this alert")
@@ -377,7 +377,7 @@ case class TeamAlertConfigBuilder(
    *  status code in a 15-minute window, where there are at least 5 total 5xx status codes observed in the time window </pre> </pre>
     */
   def withHttp5xxPercentThreshold(percentThreshold: Double, minimumHttp5xxCountThreshold: Int = 0, severity: AlertSeverity = AlertSeverity.Critical): TeamAlertConfigBuilder =
-    if (percentThreshold >= 100) {
+    if (percentThreshold > 100) {
       println(Console.CYAN + s" = ${percentThreshold}" + Console.RESET)
       throw new Exception(
         s"withHttp5xxPercentThreshold percentThreshold '${percentThreshold}' cannot be over 100% - use .disableHttp5xxPercentThreshold() to disable this alert")

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/AlertConfigBuilder.scala
@@ -129,6 +129,10 @@ case class AlertConfigBuilder(
   def withHttp90PercentileResponseTimeThreshold(threshold: Http90PercentileResponseTimeThreshold): AlertConfigBuilder = {
     if (http90PercentileResponseTimeThresholds.nonEmpty) {
       throw new Exception("withHttp90PercentileResponseTimeThreshold has already been defined for this microservice")
+    } else if (threshold.timePeriod < 0 || threshold.timePeriod > 15) {
+      println(Console.CYAN + s" = ${threshold}" + Console.RESET)
+      throw new Exception(
+        s"withHttp90PercentileResponseTimeThreshold timePeriod '${threshold.timePeriod}' needs to be in the range 1-15 minutes (inclusive)")
     } else {
       this.copy(http90PercentileResponseTimeThresholds = Seq(threshold))
     }


### PR DESCRIPTION
What did we do?
--

1. Made validation fail only if Http5xxPercentThreshold is set to OVER 100% (100% itself is valid)
2. Copied validation for Http90PercentileResponseTimeThreshold from TeamAlertConfigBuilder to AlertConfigBuilder so that the functionality is identical

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4770

Evidence of work
--

1. Passing tests