### PR TITLE
TEL-4805 allow generating multiple alerts (per instance) from graphite checks

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
@@ -28,8 +28,8 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   Name that the alert will be created with
   * @param alertPerInstance
   *   Whether to generate multiple alerts if the graphite metric query produces multiple result instances
-  * @param pendingPeriodMinutes
-  *   Amount of time in minutes that a threshold needs to be breached before the alert fires
+  * @param checkIntervalMinutes
+  *   Number of minutes between each check. See [[CheckIntervalMinutes]] for supported values
   * @param dashboardUri
   *   Grafana uri to link to. This should just be the uri path and not include the domain
   * @param dashboardPanelId
@@ -38,10 +38,13 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   Which PagerDuty integrations to direct this alert to
   * @param operator
   *   Whether to evaluate the metric as greater than or less than
+  * @param pendingPeriodMinutes
+  *   Amount of time in minutes that a threshold needs to be breached before the alert fires
   * @param query
   *   Graphite query you're running
-  * @param teamName
-  *   All alerts are prefixed with the team name
+  * @param queryTimeRangeMinutes
+  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one
+  *   minute ago (so that only fully shipped metrics are evaluated).
   * @param reducerFunction
   *   Function to use to transform multiple data points returned from query into a single value, to be compared against the specified threshold. Valid
   *   values include: COUNT, LAST, MAX, MEAN, MIN, SUM. Note: Using the LAST reducer could result in not all data points being considered during alert
@@ -54,13 +57,10 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   The severity of this alert. E.g. Warning or Critical
   * @param summary
   *   The description to populate in PagerDuty when the alert fires
+  * @param teamName
+  *   All alerts are prefixed with the team name
   * @param thresholds
   *   Trigger point for each environment
-  * @param checkIntervalMinutes
-  *   Number of minutes between each check. See [[CheckIntervalMinutes]] for supported values
-  * @param queryTimeRangeMinutes
-  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one
-  *   minute ago (so that only fully shipped metrics are evaluated).
   */
 case class CustomGraphiteMetricAlert(
     alertName: String,

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
@@ -26,6 +26,8 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *
   * @param alertName
   *   Name that the alert will be created with
+  * @param alertPerInstance
+  *   Whether to generate multiple alerts if the graphite metric query produces multiple result instances
   * @param pendingPeriodMinutes
   *   Amount of time in minutes that a threshold needs to be breached before the alert fires
   * @param dashboardUri
@@ -62,18 +64,19 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   */
 case class CustomGraphiteMetricAlert(
     alertName: String,
+    alertPerInstance: Boolean = false,
     checkIntervalMinutes: Option[CheckIntervalMinutes] = None,
-    pendingPeriodMinutes: Option[Int] = None,
-    dashboardUri: Option[String],
     dashboardPanelId: Option[Int],
+    dashboardUri: Option[String],
     integrations: Seq[String],
     operator: EvaluationOperator,
+    pendingPeriodMinutes: Option[Int] = None,
     query: String,
-    teamName: String,
+    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES,
     reducerFunction: ReducerFunction,
     runbookUrl: Option[String],
     severity: AlertSeverity,
     summary: String,
-    thresholds: EnvironmentThresholds,
-    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES
+    teamName: String,
+    thresholds: EnvironmentThresholds
 ) extends CustomAlert

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomGraphiteMetricAlert.scala
@@ -30,10 +30,10 @@ import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinu
   *   Whether to generate multiple alerts if the graphite metric query produces multiple result instances
   * @param checkIntervalMinutes
   *   Number of minutes between each check. See [[CheckIntervalMinutes]] for supported values
-  * @param dashboardUri
-  *   Grafana uri to link to. This should just be the uri path and not include the domain
   * @param dashboardPanelId
   *   Specific panel to deep link to that is specific to this alert
+  * @param dashboardUri
+  *   Grafana uri to link to. This should just be the uri path and not include the domain
   * @param integrations
   *   Which PagerDuty integrations to direct this alert to
   * @param operator


### PR DESCRIPTION
What did we do?
--

1. Add alertPerInstance parameter to custom graphite alerts to replicate the functionality of [check_graphite_wildcard](https://github.com/hmrc/aws-ami-telemetry-sensu/blob/main/files/sensu/plugins/check-graphite-wildcard.rb) sensu plugin
2. Sorted parameters for some reason that I need healing from!

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4805

Evidence of work
--

1. Tested by building from branch and using in alert-config and telemetry-grafana-alert-config
<img width="176" alt="image" src="https://github.com/user-attachments/assets/b939aa96-7932-4e68-9421-8e45ddddb4e1">
<img width="639" alt="image" src="https://github.com/user-attachments/assets/95cdb644-3e1f-4fc7-b415-9f979a1f2369">
<img width="594" alt="image" src="https://github.com/user-attachments/assets/f22d2cfe-be6d-412e-bf52-cae8ca382493">

Next Steps
--

1. Update library version in alert-config and deploy example/test using telemetry-grafana-alert-config
