### PR TITLE
TEL-4802 add custom alert type for percentage split alert based on logs

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertConfigYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertConfigYamlBuilder.scala
@@ -26,7 +26,7 @@ case class CustomAlertsTopLevel(alerts: CustomAlerts)
 case class CustomAlerts(
     customElasticsearchAlerts: Seq[CustomElasticsearchAlert],
     customElasticsearchPercentageAlerts: Seq[CustomElasticsearchPercentageAlert],
-    customElasticsearchPercentageSplitAlert: Seq[CustomElasticsearchPercentageSplitAlert],
+    customElasticsearchPercentageSplitAlerts: Seq[CustomElasticsearchPercentageSplitAlert],
     customGraphiteMetricAlerts: Seq[CustomGraphiteMetricAlert],
     customCloudWatchMetricAlerts: Seq[CustomCloudWatchMetricAlert]
 )
@@ -64,7 +64,7 @@ object CustomAlertConfigYamlBuilder {
       }
 
     val separatedAlerts = CustomAlertsTopLevel(
-      CustomAlerts(customElasticsearchAlerts, customElasticsearchPercentageAlerts, customGraphiteMetricAlerts, customCloudWatchMetricAlerts))
+      CustomAlerts(customElasticsearchAlerts, customElasticsearchPercentageAlerts, customElasticsearchPercentageSplitAlerts, customGraphiteMetricAlerts, customCloudWatchMetricAlerts))
 
     mapper.writeValue(saveLocation, separatedAlerts)
   }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertConfigYamlBuilder.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomAlertConfigYamlBuilder.scala
@@ -26,6 +26,7 @@ case class CustomAlertsTopLevel(alerts: CustomAlerts)
 case class CustomAlerts(
     customElasticsearchAlerts: Seq[CustomElasticsearchAlert],
     customElasticsearchPercentageAlerts: Seq[CustomElasticsearchPercentageAlert],
+    customElasticsearchPercentageSplitAlert: Seq[CustomElasticsearchPercentageSplitAlert],
     customGraphiteMetricAlerts: Seq[CustomGraphiteMetricAlert],
     customCloudWatchMetricAlerts: Seq[CustomCloudWatchMetricAlert]
 )
@@ -44,6 +45,11 @@ object CustomAlertConfigYamlBuilder {
 
     val customElasticsearchPercentageAlerts: Seq[CustomElasticsearchPercentageAlert] = activeAlerts
       .collect { case alert: CustomElasticsearchPercentageAlert =>
+        alert.copy(thresholds = alert.thresholds.removeAllOtherEnvironmentThresholds(currentEnvironment))
+      }
+
+    val customElasticsearchPercentageSplitAlerts: Seq[CustomElasticsearchPercentageSplitAlert] = activeAlerts
+      .collect { case alert: CustomElasticsearchPercentageSplitAlert =>
         alert.copy(thresholds = alert.thresholds.removeAllOtherEnvironmentThresholds(currentEnvironment))
       }
 
@@ -94,10 +100,11 @@ object CustomAlertConfigYamlBuilder {
     */
   private def isAlertDefinedForEnv(alert: CustomAlert, currentEnvironment: Environment): Boolean = {
     alert match {
-      case alert: CustomCloudWatchMetricAlert        => alert.thresholds.isEnvironmentDefined(currentEnvironment)
-      case alert: CustomElasticsearchAlert           => alert.thresholds.isEnvironmentDefined(currentEnvironment)
-      case alert: CustomElasticsearchPercentageAlert => alert.thresholds.isEnvironmentDefined(currentEnvironment)
-      case alert: CustomGraphiteMetricAlert          => alert.thresholds.isEnvironmentDefined(currentEnvironment)
+      case alert: CustomCloudWatchMetricAlert             => alert.thresholds.isEnvironmentDefined(currentEnvironment)
+      case alert: CustomElasticsearchAlert                => alert.thresholds.isEnvironmentDefined(currentEnvironment)
+      case alert: CustomElasticsearchPercentageAlert      => alert.thresholds.isEnvironmentDefined(currentEnvironment)
+      case alert: CustomElasticsearchPercentageSplitAlert => alert.thresholds.isEnvironmentDefined(currentEnvironment)
+      case alert: CustomGraphiteMetricAlert               => alert.thresholds.isEnvironmentDefined(currentEnvironment)
       case other => throw new IllegalArgumentException(s"isAlertDefinedForEnv is not defined for ${other.getClass.getSimpleName}. Please update it.")
     }
   }
@@ -128,10 +135,11 @@ object CustomAlertConfigYamlBuilder {
     */
   private def updateIntegrationsForCustomAlert(customAlert: CustomAlert, enabledIntegrations: Seq[String]): CustomAlert = {
     customAlert match {
-      case alert: CustomCloudWatchMetricAlert        => alert.copy(integrations = enabledIntegrations)
-      case alert: CustomElasticsearchAlert           => alert.copy(integrations = enabledIntegrations)
-      case alert: CustomElasticsearchPercentageAlert => alert.copy(integrations = enabledIntegrations)
-      case alert: CustomGraphiteMetricAlert          => alert.copy(integrations = enabledIntegrations)
+      case alert: CustomCloudWatchMetricAlert             => alert.copy(integrations = enabledIntegrations)
+      case alert: CustomElasticsearchAlert                => alert.copy(integrations = enabledIntegrations)
+      case alert: CustomElasticsearchPercentageAlert      => alert.copy(integrations = enabledIntegrations)
+      case alert: CustomElasticsearchPercentageSplitAlert => alert.copy(integrations = enabledIntegrations)
+      case alert: CustomGraphiteMetricAlert               => alert.copy(integrations = enabledIntegrations)
       case other => throw new IllegalArgumentException(s"Unsupported CustomAlert type: ${customAlert.getClass.getName}")
     }
   }

--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchPercentageSplitAlert.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/CustomElasticsearchPercentageSplitAlert.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.alertconfig.builder.custom
+
+import uk.gov.hmrc.alertconfig.builder.custom.CheckIntervalMinutes.CheckIntervalMinutes
+import uk.gov.hmrc.alertconfig.builder.custom.CustomAlertSeverity.AlertSeverity
+import uk.gov.hmrc.alertconfig.builder.custom.EvaluationOperator.EvaluationOperator
+import uk.gov.hmrc.alertconfig.builder.custom.TimeRangeAsMinutes.TimeRangeAsMinutes
+
+/** Custom ElasticSearch alert based on the percentage of a subset of records, unless total records is lower than splitThreshold, in which case use an
+  * absolute threshold
+  *
+  * @param absoluteThreshold
+  *   Threshold to alert during low-traffic scenario
+  * @param alertName
+  *   Name that the alert will be created with
+  * @param checkIntervalMinutes
+  *   Number of minutes between each check. See [[CheckIntervalMinutes]] for supported values
+  * @param integrations
+  *   Which PagerDuty integrations to direct this alert to n
+  * @param kibanaDashboardUri
+  *   (Optional) Kibana uri to link to. This should just be the uri path and not include the domain
+  * @param luceneQuerySubset
+  *   Query to make to Elasticsearch to get subset of records (to calculate as percentage of luceneQueryTotal)
+  * @param luceneQueryTotal
+  *   Query to make to Elasticsearch to get total records (to calculate percentage from)
+  * @param operator
+  *   Whether to evaluate the metric as greater than or less than
+  * @param pendingPeriodMinutes
+  *   Amount of time in minutes that a threshold needs to be breached before the alert fires. Defaults to fire immediately
+  * @param queryTimeRangeMinutes
+  *   The sample period to check data for. If you set it to FIVE_MINUTES, the alert check will evaluate data starting from 6 minutes ago until one
+  *   minute ago (so that only fully shipped metrics are evaluated).
+  * @param runbookUrl
+  *   (Optional) Runbook for when this alert fires
+  * @param severity
+  *   The severity of this alert. E.g. Warning or Critical
+  * @param splitThreshold
+  *   The number of records that indicates a low-traffic scenario. Above this number will use the percentage threshold, below this number will use the
+  *   absolute threshold
+  * @param summary
+  *   The description to populate in PagerDuty when the alert fires
+  * @param teamName
+  *   All alerts are prefixed with the team name
+  * @param thresholds
+  *   Trigger point for each environment
+  */
+case class CustomElasticsearchPercentageSplitAlert(
+    absoluteThreshold: Int,
+    alertName: String,
+    checkIntervalMinutes: Option[CheckIntervalMinutes] = None,
+    integrations: Seq[String],
+    kibanaDashboardUri: Option[String] = None,
+    luceneQuerySubset: String,
+    luceneQueryTotal: String,
+    operator: EvaluationOperator = EvaluationOperator.GREATER_THAN,
+    pendingPeriodMinutes: Option[Int] = None,
+    queryTimeRangeMinutes: TimeRangeAsMinutes = TimeRangeAsMinutes.FIFTEEN_MINUTES,
+    runbookUrl: Option[String] = None,
+    severity: AlertSeverity,
+    splitThreshold: Int,
+    summary: String,
+    teamName: String,
+    thresholds: EnvironmentThresholds
+) extends CustomAlert


### PR DESCRIPTION
What did we do?
--

1. Add new custom alert type for alerting on either a percentage of a subset of logs (when total logs is above 'split' threshold), or an absolute threshold (when total logs is below 'split' threshold)

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4802

Evidence of work
--

1. Tested from branch:

Alerts on absolute threshold when total records is <= split threshold:
<img width="658" alt="image" src="https://github.com/user-attachments/assets/ed34da2b-c23b-4296-915d-5b69a1edc840">

Alerts on percentage threshold when total records is > split threshold:
<img width="654" alt="image" src="https://github.com/user-attachments/assets/f05563f6-23f7-4337-a3b4-4551babc40c2">

Next Steps
--

1. Add alert in alert-config
2. Add new terraform module

Collaboration
--

Co-authored-by: Muhammed Ahmed <ma3574@users.noreply.github.com>
