### PR TITLE
TEL-4841 add some more time ranges

### DIFF
--- a/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
+++ b/src/main/scala/uk/gov/hmrc/alertconfig/builder/custom/TimeRangeAsMinutes.scala
@@ -25,6 +25,8 @@ object TimeRangeAsMinutes {
   val THREE_MINUTES     = 3
   val FOUR_MINUTES      = 4
   val FIVE_MINUTES      = 5
+  val SIX_MINUTES       = 6
+  val EIGHT_MINUTES     = 8
   val TEN_MINUTES       = 10
   val FIFTEEN_MINUTES   = 15
   val SIXTEEN_MINUTES   = 16


### PR DESCRIPTION
What did we do?
--

1. Added 6 & 8 minutes to TimeRangeAsMinutes type

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4841

Evidence of work
--

1. passing tests

Next Steps
--

1. Update alert-config to use the correct type

Risks
--

1. Smoke and mirrors, you can just use any integer

Collaboration
--

Co-authored-by: Muhammed Ahmed <ma3574@users.noreply.github.com>

